### PR TITLE
Consider parent opacity when deciding element visibility

### DIFF
--- a/.changeset/happy-timers-complain.md
+++ b/.changeset/happy-timers-complain.md
@@ -1,0 +1,5 @@
+---
+'@qualweb/util': patch
+---
+
+When parent has opacity zero consider element not visible

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qualweb/util",
-  "version": "0.5.28",
+  "version": "0.5.29",
   "description": "Utilities module for qualweb",
   "main": "dist/util.bundle.js",
   "files": [

--- a/packages/util/src/domUtils/isElementVisible.ts
+++ b/packages/util/src/domUtils/isElementVisible.ts
@@ -2,17 +2,36 @@ import elementHasOnePixel from './elementHasOnePixel';
 import elementHasContent from './elementHasContent';
 
 function isElementVisible(element: typeof window.qwElement): boolean {
-  const offScreen = element.isOffScreen();
-  const cssHidden = window.DomUtils.isElementHiddenByCSS(element);
-  const hasContent = elementHasContent(element, true);
-  const hasOnePixelHeight = elementHasOnePixel(element);
-  const opacityProperty = element.getElementStyleProperty('opacity', '');
-  let opacity: number | undefined;
-  if (opacityProperty) {
-    opacity = parseInt(opacityProperty);
-  }
+    const offScreen = element.isOffScreen();
+    const cssHidden = window.DomUtils.isElementHiddenByCSS(element);
+    const hasContent = elementHasContent(element, true);
+    const hasOnePixelHeight = elementHasOnePixel(element);
+    const opacityProperty = element.getElementStyleProperty('opacity', '');
+    let opacity: number | undefined;
+    if (opacityProperty) {
+        opacity = parseInt(opacityProperty);
+    }
+    let opaqueParent: boolean = false;
+    if (element.getElementParent()) {
+        opaqueParent = isParentOpaque(element.getElementParent()!);
+    }
 
-  return !(offScreen || hasOnePixelHeight || cssHidden || !hasContent || (opacity && opacity === 0));
+    return !(offScreen || hasOnePixelHeight || cssHidden || !hasContent || (opacity && opacity === 0) || !opaqueParent);
+}
+
+function isParentOpaque(element: typeof window.qwElement): boolean {
+    const opacityProperty = element.getElementStyleProperty('opacity', '');
+    let opacity: number | undefined;
+    if (opacityProperty) {
+        opacity = parseInt(opacityProperty);
+    }
+    if (opacity && opacity === 0) {
+        return true;
+    }
+    if (element.getElementParent()) {
+        return isParentOpaque(element.getElementParent()!);
+    }
+    return false;
 }
 
 export default isElementVisible;


### PR DESCRIPTION
When parent has opacity equal 0 then consider element as not visible

Closes: #70 