### PR TITLE
Bug: Added missing "nn" and "nb" to type Lang

### DIFF
--- a/packages/types/locale.d.ts
+++ b/packages/types/locale.d.ts
@@ -29,7 +29,7 @@ declare module "@qualweb/locale" {
     fallback: Locale;
   }
 
-  type Lang = "en" | "fi" | "sv";
+  type Lang = "en" | "fi" | "sv" | "nb" |"nn" ;
 
   interface Langs {
     en: Locale;


### PR DESCRIPTION
Added missing language-tag "nb" and "nn" to type Lang. 