### PR TITLE
chore: remove package-lock.json from .gitignore files

### DIFF
--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -2,4 +2,3 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 qualweb-errors-*.log

--- a/packages/counter/.gitignore
+++ b/packages/counter/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea

--- a/packages/crawler/.gitignore
+++ b/packages/crawler/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea

--- a/packages/dom/.gitignore
+++ b/packages/dom/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea

--- a/packages/earl-reporter/.gitignore
+++ b/packages/earl-reporter/.gitignore
@@ -2,4 +2,3 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json

--- a/packages/evaluation/.gitignore
+++ b/packages/evaluation/.gitignore
@@ -2,4 +2,3 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json

--- a/packages/locale/.gitignore
+++ b/packages/locale/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea

--- a/packages/qw-element/.gitignore
+++ b/packages/qw-element/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea

--- a/packages/qw-page/.gitignore
+++ b/packages/qw-page/.gitignore
@@ -2,5 +2,4 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea

--- a/packages/types/.gitignore
+++ b/packages/types/.gitignore
@@ -2,4 +2,3 @@ node_modules
 .idea
 /.yalc
 yalc.lock
-package-lock.json

--- a/packages/util/.gitignore
+++ b/packages/util/.gitignore
@@ -3,5 +3,4 @@
 /.yalc
 yalc.lock
 /.idea
-package-lock.json
 /prebuild

--- a/packages/wcag-techniques/.gitignore
+++ b/packages/wcag-techniques/.gitignore
@@ -2,6 +2,5 @@
 /node_modules
 /.yalc
 yalc.lock
-package-lock.json
 .idea
 Output.txt


### PR DESCRIPTION
I noticed that most of the .gitignore files still explicitly ignore package-lock.json

AFAIK, it's still best practice to commit the file to git.

This PR just removes the entry from all .gitignore files in the monorepo.