### PR TITLE
@qualweb/dom: fix unit tests (#10)

### DIFF
--- a/packages/dom/.mocharc.js
+++ b/packages/dom/.mocharc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  "color": true,
+  "ui": "bdd",
+  "spec": "test/**/*.spec.mjs",
+  // Uncomment to get a JSON file with test results instead of output in console.
+  // "reporter": "json",
+  // "reporterOptions": [
+  //   "output=./results.json",
+  // ],
+}

--- a/packages/dom/test/dom.spec.mjs
+++ b/packages/dom/test/dom.spec.mjs
@@ -1,33 +1,54 @@
-import { Dom } from '../dist/index.js';
-import puppeteer from 'puppeteer';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { expect } from 'chai';
 
-describe('HTML validation', function () {
-  it('should be undefined', async function () {
-    this.timeout(0);
-    const browser = await puppeteer.launch({ headless: true });
-    const incognito = await browser.createIncognitoBrowserContext();
-    const page = await incognito.newPage();
-    const dom = new Dom(page);
-    const { validation } = await dom.process({}, 'https://ciencias.ulisboa.pt', '');
+import { Dom } from '../dist/index.js';
+import puppeteer from 'puppeteer';
 
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+describe('dom.process()', () => {
+  let browser;
+  let incognito;
+  let page;
+
+  beforeEach(async () => {
+    browser = await puppeteer.launch({
+      headless: 'new',
+    });
+    incognito = await browser.createIncognitoBrowserContext();
+    page = await incognito.newPage();
+  });
+
+  afterEach(async () => {
     await page.close();
     await incognito.close();
     await browser.close();
+  })
+
+  it('No ACT/WCAG execution intent should not yield validation', async function () {
+    this.timeout(0);
+    
+    const emptyHtmlFile = readFileSync(resolve(__dirname, 'fixtures/empty.html'));
+
+    const dom = new Dom(page);
+
+    const { validation } = await dom.process({}, '', emptyHtmlFile);
 
     expect(validation).to.be.undefined;
   });
-  it('should not be undefined', async function () {
+  it('ACT/WCAG execution intent must yield validation', async function () {
     this.timeout(0);
-    const browser = await puppeteer.launch({ headless: true });
-    const incognito = await browser.createIncognitoBrowserContext();
-    const page = await incognito.newPage();
-    const dom = new Dom(page /** INSERT ENDPOINT HERE **/);
-    const { validation } = await dom.process({ execute: { wcag: true } }, 'https://ciencias.ulisboa.pt', '');
 
-    await page.close();
-    await incognito.close();
-    await browser.close();
+    const emptyHtmlFile = readFileSync(resolve(__dirname, 'fixtures/empty.html'));
+
+    const dom = new Dom(page, /** MISSING VALIDATOR HERE! */);
+
+    const { validation } = await dom.process({ execute: { wcag: true } }, '', emptyHtmlFile);
+
+    console.debug(validation);
 
     expect(validation).to.not.be.undefined;
   });

--- a/packages/dom/test/fixtures/empty.html
+++ b/packages/dom/test/fixtures/empty.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head></head>
+  <body>
+    <div>
+      <p>
+        This is an intentionally empty page.
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR fixes #10 and #22 

I've only gotten the tests back into running shape and pointed them towards a local file fixture instead of a remote URL.

It looks like one of the unit tests is failing because it is incorrectly implemented. When creating a new `Dom` object for the test, it doesn't pass a validator string. This, in turn, prevents a `validation` object from being produced in `Dom#process()`. Looking over the monorepo's source code, I can't find an example of this use, so I don't know how to correct the unit.

I think merging this PR and closing the issues is fine. Our initial goal is still to get the unit tests running again, not to make a pristine set of tests, just yet :smile: 