### PR TITLE
Upgrade QW-ACT-R62

### DIFF
--- a/packages/act-rules/src/index.ts
+++ b/packages/act-rules/src/index.ts
@@ -216,6 +216,21 @@ class ACTRules {
     }
   }
 
+  public validateVisibleFocus(): void {
+    if (this.rulesToExecute['QW-ACT-R62']) {
+      const elements = window.qwPage.getElements('*');
+
+      for (const elem of elements ?? []) {
+        if (window.AccessibilityUtils.isPartOfSequentialFocusNavigation(elem)) {
+          this.rules['QW-ACT-R62'].execute(elem);
+        }
+      }
+
+      this.report.assertions['QW-ACT-R62'] = this.rules['QW-ACT-R62'].getFinalResults();
+      this.report.metadata[this.report.assertions['QW-ACT-R62'].metadata.outcome]++;
+    }
+  }
+
   public validateFirstFocusableElementIsLinkToNonRepeatedContent(): void {
     if (this.rulesToExecute['QW-ACT-R72']) {
       this.rules['QW-ACT-R72'].execute(undefined);

--- a/packages/act-rules/src/lib/rules.ts
+++ b/packages/act-rules/src/lib/rules.ts
@@ -135,5 +135,5 @@ export {
   QW_ACT_R75,
   QW_ACT_R76,
   QW_ACT_R77,
-  QW_ACT_R9,
+  QW_ACT_R9
 };

--- a/packages/act-rules/src/rules/QW-ACT-R62.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R62.ts
@@ -12,17 +12,18 @@ class QW_ACT_R62 extends AtomicRule {
 
   @ElementExists
   execute(element: typeof window.qwElement): void {
-    const elementList = element.getElements('*');
-    const inSequentialFocusList = elementList.filter((element) => {
-      return window.AccessibilityUtils.isPartOfSequentialFocusNavigation(element);
-    });
-
-    if (inSequentialFocusList.length >= 1) {
-      for (const inSequentialFocusElement of inSequentialFocusList ?? []) {
-        const test = new Test('warning', undefined, 'W1');
-        test.addElement(inSequentialFocusElement);
-        super.addTestResult(test);
-      }
+    const diff = element.getElementAttribute('data-qw-act-r62');
+    if (diff === null) {
+      return;
+    }
+    if (diff === 'true') {
+      const test = new Test('passed', undefined, 'P1');
+      test.addElement(element);
+      super.addTestResult(test);
+    } else {
+      const test = new Test('failed', undefined, 'F1');
+      test.addElement(element);
+      super.addTestResult(test);
     }
   }
 }

--- a/packages/act-rules/test/rule.spec.ts
+++ b/packages/act-rules/test/rule.spec.ts
@@ -8,7 +8,7 @@
 import { Dom } from '@qualweb/dom';
 import { expect } from 'chai';
 import locales from '@qualweb/locale';
-import { launchBrowser } from './util';
+import { launchBrowser, processForR62 } from './util';
 
 import actTestCases from './fixtures/testcases.json';
 import type { Browser, BrowserContext } from 'puppeteer';
@@ -102,7 +102,7 @@ const CANTTELL = 'cantTell';
 const consistencyMapping = {
   passed: [PASSED, INAPPLICABLE, CANTTELL],
   failed: [FAILED, CANTTELL],
-  inapplicable: [PASSED, INAPPLICABLE, CANTTELL],
+  inapplicable: [PASSED, INAPPLICABLE, CANTTELL]
 };
 
 describe('ACT rules', () => {
@@ -223,6 +223,13 @@ describe('ACT rules', () => {
             });
           }
 
+          if (ruleId === 'oj04fd') {
+            await processForR62(page);
+            await page.evaluate(() => {
+              window.act.validateVisibleFocus();
+            });
+          }
+
           const report = await page.evaluate(() => {
             window.act.validateZoomedTextNodeNotClippedWithCSSOverflow();
             return window.act.getReport();
@@ -234,6 +241,7 @@ describe('ACT rules', () => {
               ? report.assertions[ruleToTest].metadata.outcome
               : CANTTELL;
 
+          console.log(`Test outcome: ${outcome}`);
           // These implementation tests pass if the result from the ACT rule
           // falls within a range of acceptable outcomes.
           expect(outcome).to.be.oneOf(consistencyMapping[test.outcome as keyof typeof consistencyMapping]);

--- a/packages/act-rules/test/url.spec.ts
+++ b/packages/act-rules/test/url.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import fetch from 'node-fetch';
-import { launchBrowser } from './util';
+import { launchBrowser, processForR62 } from './util';
 import { Dom } from '@qualweb/dom';
 import locales from '@qualweb/locale';
 import { Browser } from 'puppeteer';
@@ -15,7 +15,9 @@ describe('URL evaluation', function () {
   it('Evaluates url', async function () {
     this.timeout(0);
 
-    const url = 'https://bth.se/';
+    const testingR62: boolean = true;
+
+    const url = 'http://www.worten.pt/';
     const response = await fetch(url);
     const sourceCode = await response.text();
 
@@ -42,7 +44,7 @@ describe('URL evaluation', function () {
       (fiLocale, enLocale, sourceCode) => {
         // @ts-expect-error: ACTRules will be defined within the puppeteer execution context.
         window.act = new ACTRules({ translate: fiLocale, fallback: enLocale });
-        //window.act.configure({ rules: ['QW-ACT-R37'] });
+        window.act.configure({ rules: ['QW-ACT-R62'] });
         window.act.validateFirstFocusableElementIsLinkToNonRepeatedContent();
 
         const parser = new DOMParser();
@@ -69,6 +71,13 @@ describe('URL evaluation', function () {
       width: 640,
       height: 512
     });
+
+    if (testingR62) {
+      await processForR62(page);
+      await page.evaluate(() => {
+        window.act.validateVisibleFocus();
+      });
+    }
 
     const report = await page.evaluate(() => {
       window.act.validateZoomedTextNodeNotClippedWithCSSOverflow();

--- a/packages/act-rules/test/util.ts
+++ b/packages/act-rules/test/util.ts
@@ -1,4 +1,4 @@
-import puppeteer from 'puppeteer';
+import puppeteer, { Page, ScreenshotClip, ScreenshotOptions } from 'puppeteer';
 
 export async function launchBrowser() {
   const args = [];
@@ -9,4 +9,63 @@ export async function launchBrowser() {
     headless: process.env.TEST_PUPPETEER_HEADLESS?.toLowerCase() === 'false' || 'new',
     args
   });
+}
+
+export async function processForR62(page: Page) {
+  // get selectors of all elements that are part of the sequential focus navigation
+  const selectors: string[] = await page.evaluate(() => {
+    const selectors: string[] = [];
+    const elements = window.qwPage.getElements('*');
+    for (const elem of elements ?? []) {
+      if (window.AccessibilityUtils.isPartOfSequentialFocusNavigation(elem)) {
+        selectors.push(elem.getElementSelector());
+      }
+    }
+    return selectors;
+  });
+  const extraMargin = 30;
+  const body = await page.$('body');
+  for (const selector of selectors) {
+    // get the bounding box of the element
+    const el = await page.$(selector);
+    if (el === null) {
+      process.stdout.write('.');
+      continue;
+    }
+    await page.waitForSelector(selector);
+    const rect = await el.boundingBox();
+    if (rect === null) {
+      continue;
+    }
+    // increase the bounding box to take a screenshot
+    const screenClip: ScreenshotClip = {
+      x: rect.x - extraMargin,
+      y: rect.y - extraMargin,
+      width: rect.width + extraMargin * 2,
+      height: rect.height + extraMargin * 2
+    };
+    const options: ScreenshotOptions = {
+      clip: screenClip,
+      type: 'webp',
+      quality: 0,
+      optimizeForSpeed: true
+    };
+    // take a screenshot of the element
+    const originalScreenshot = await page.screenshot(options);
+    // focus the element
+    el.focus();
+    // take another screenshot of the element
+    const focusedScreenshot = await page.screenshot(options);
+    body?.focus();
+    // compare the screenshots
+    const diff = originalScreenshot.compare(focusedScreenshot) === 0 ? 'false' : 'true';
+    await page.evaluate(
+      (selector, diff) => {
+        const elem = window.qwPage.getElement(selector)!;
+        elem.setElementAttribute('data-qw-act-r62', diff);
+      },
+      selector,
+      diff
+    );
+  }
 }

--- a/packages/qw-element/src/index.ts
+++ b/packages/qw-element/src/index.ts
@@ -656,6 +656,11 @@ class QWElement {
     htmlElement.focus();
   }
 
+  public blurElement(): void {
+    const htmlElement = <HTMLElement>this.element;
+    htmlElement.blur();
+  }
+
   public dispatchEvent(event: Event): void {
     const htmlElement = <HTMLElement>this.element;
     htmlElement.dispatchEvent(event);

--- a/packages/types/act-rules.d.ts
+++ b/packages/types/act-rules.d.ts
@@ -197,6 +197,7 @@ declare module "@qualweb/act-rules" {
     public validateMetaElements(metaElements: Array<QWElement>): void;
     public validateZoomedTextNodeNotClippedWithCSSOverflow(): void;
     public validateFirstFocusableElementIsLinkToNonRepeatedContent(): void;
+    public validateVisibleFocus(): void;
     public getReport(): ACTRulesReport;
 
     private executeRule(rule: string, selector: string): void;

--- a/packages/types/qwElement.d.ts
+++ b/packages/types/qwElement.d.ts
@@ -67,6 +67,7 @@ declare module "@qualweb/qw-element" {
     public elementHasTextNode(): boolean;
     public getContentFrame(): Document | null;
     public focusElement(): void;
+    public blurElement(): void;
     public dispatchEvent(event: Event): void;
     public click(): void;
     public getBoundingBox(): DOMRect;


### PR DESCRIPTION
Compares screenshots of elements in sequential focus order before and after they are being focused to find if there is a visible focus indicator.

**Needs performance improvement.** 

Works fine on ACT tests and small webpages. 
Pages with larger number of focusable elements sometimes throw a timeout error for page.screenshot 