### PR TITLE
Bugfix in opacity comparison.

### DIFF
--- a/packages/util/src/domUtils/isElementVisible.ts
+++ b/packages/util/src/domUtils/isElementVisible.ts
@@ -16,7 +16,7 @@ function isElementVisible(element: typeof window.qwElement): boolean {
     opaqueParent = isParentOpaque(element.getElementParent()!);
   }
 
-  return !(offScreen || hasOnePixelHeight || cssHidden || !hasContent || (opacity && opacity === 0) || opaqueParent);
+  return !(offScreen || hasOnePixelHeight || cssHidden || !hasContent || (opacity != undefined && opacity === 0) || opaqueParent);
 }
 
 function isParentOpaque(element: typeof window.qwElement): boolean {
@@ -25,7 +25,7 @@ function isParentOpaque(element: typeof window.qwElement): boolean {
   if (opacityProperty) {
     opacity = parseInt(opacityProperty);
   }
-  if (opacity && opacity === 0) {
+  if (opacity != undefined && opacity === 0) {
     return true;
   }
   if (element.getElementParent()) {

--- a/packages/util/src/domUtils/isElementVisible.ts
+++ b/packages/util/src/domUtils/isElementVisible.ts
@@ -9,7 +9,7 @@ function isElementVisible(element: typeof window.qwElement): boolean {
   const opacityProperty = element.getElementStyleProperty('opacity', '');
   let opacity: number | undefined;
   if (opacityProperty) {
-    opacity = parseInt(opacityProperty);
+    opacity = parseFloat(opacityProperty);
   }
   let opaqueParent: boolean = false;
   if (element.getElementParent()) {
@@ -23,7 +23,7 @@ function isParentOpaque(element: typeof window.qwElement): boolean {
   const opacityProperty = element.getElementStyleProperty('opacity', '');
   let opacity: number | undefined;
   if (opacityProperty) {
-    opacity = parseInt(opacityProperty);
+    opacity = parseFloat(opacityProperty);
   }
   if (opacity != undefined && opacity === 0) {
     return true;


### PR DESCRIPTION
when element's opacity value is 0 the evaluation if(opacity) will always return false and therefore (opacity && opacity === 0) can never return true.