### PR TITLE
`QualWeb.evaluate()` incorrectly evaluates HTML code when no code was passed in options

### DIFF
--- a/packages/core/src/qualweb.ts
+++ b/packages/core/src/qualweb.ts
@@ -112,7 +112,10 @@ export class QualWeb {
 
     await this.handlePageEvaluations(reports, options);
     this.addUrlsToEvaluate(urls);
-    this.addHtmlCodeToEvaluate(options.html);
+
+    if (options.html) {
+      this.addHtmlCodeToEvaluate(options.html);
+    }
 
     await this.cluster?.idle();
 


### PR DESCRIPTION
Quick fix.

Just adds a check to make sure that `options.html` is actually defined before tasking the cluster with running an evaluation for it.