### PR TITLE
Update all homepage/repository/bugs links

### DIFF
--- a/.changeset/red-islands-teach.md
+++ b/.changeset/red-islands-teach.md
@@ -1,0 +1,17 @@
+---
+'@qualweb/wcag-techniques': patch
+'@qualweb/best-practices': patch
+'@qualweb/earl-reporter': patch
+'@qualweb/cui-checks': patch
+'@qualweb/qw-element': patch
+'@qualweb/act-rules': patch
+'@qualweb/counter': patch
+'@qualweb/crawler': patch
+'@qualweb/qw-page': patch
+'@qualweb/locale': patch
+'@qualweb/core': patch
+'@qualweb/util': patch
+'@qualweb/cli': patch
+---
+
+Updated repository, bugs, and homepage fields for all package.json files

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "git://github.com/qualweb/qualweb.git"
+    "url": "git+https://github.com/qualweb/qualweb.git"
   },
   "scripts": {
     "release": "npm -ws run build && npx changeset publish && git push --follow-tags",

--- a/packages/act-rules/package.json
+++ b/packages/act-rules/package.json
@@ -39,7 +39,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/qualweb/act-rules.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/act-rules"
   },
   "author": "João Vicente",
   "license": "ISC",

--- a/packages/best-practices/package.json
+++ b/packages/best-practices/package.json
@@ -47,7 +47,7 @@
     "build": "tsc --build tsconfig.prod.json && webpack",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/best-practices#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/best-practices",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/best-practices/package.json
+++ b/packages/best-practices/package.json
@@ -50,7 +50,8 @@
   "homepage": "https://github.com/qualweb/best-practices#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/best-practices.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/best-practices"
   },
   "bugs": {
     "url": "https://github.com/qualweb/best-practices/issues"

--- a/packages/best-practices/package.json
+++ b/packages/best-practices/package.json
@@ -54,7 +54,7 @@
     "directory": "packages/best-practices"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/best-practices/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "qualweb",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -24,7 +24,7 @@
     "a11y",
     "accessibility"
   ],
-  "homepage": "https://github.com/qualweb/cli#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/cli",
   "bugs": {
     "url": "https://github.com/qualweb/cli/issues",
     "email": "qualweb@fc.ul.pt"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,7 +31,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/qualweb/cli.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/cli"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/cli",
   "bugs": {
-    "url": "https://github.com/qualweb/cli/issues",
+    "url": "https://github.com/qualweb/qualweb/issues",
     "email": "qualweb@fc.ul.pt"
   },
   "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "accessibility",
     "a11y"
   ],
-  "homepage": "https://github.com/qualweb/core#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/core",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,7 +62,7 @@
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/core/issues",
+    "url": "https://github.com/qualweb/qualweb/issues",
     "email": "qualweb@fc.ul.pt"
   },
   "author": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,8 @@
   "homepage": "https://github.com/qualweb/core#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/qualweb/core.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/core"
   },
   "bugs": {
     "url": "https://github.com/qualweb/core/issues",

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/qualweb/counter#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/counter.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/counter"
   },
   "bugs": {
     "url": "https://github.com/qualweb/counter/issues"

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -24,7 +24,7 @@
     "directory": "packages/counter"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/counter/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "qualweb",

--- a/packages/counter/package.json
+++ b/packages/counter/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --build tsconfig.prod.json && webpack",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/counter#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/counter",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -24,7 +24,7 @@
     "directory": "packages/crawler"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/crawler/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "ally",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -17,7 +17,7 @@
     "build": "tsc --build tsconfig.prod.json",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/crawler#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/crawler",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/crawler/package.json
+++ b/packages/crawler/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/qualweb/crawler#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/crawler.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/crawler"
   },
   "bugs": {
     "url": "https://github.com/qualweb/crawler/issues"

--- a/packages/cui-checks/package.json
+++ b/packages/cui-checks/package.json
@@ -27,6 +27,7 @@
     "build": "tsc --build tsconfig.prod.json && webpack",
     "prepublishOnly": "npm run build"
   },
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/cui-checks",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/cui-checks/package.json
+++ b/packages/cui-checks/package.json
@@ -27,6 +27,11 @@
     "build": "tsc --build tsconfig.prod.json && webpack",
     "prepublishOnly": "npm run build"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/cui-checks"
+  },
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/packages/cui-checks/package.json
+++ b/packages/cui-checks/package.json
@@ -33,6 +33,9 @@
     "url": "git+https://github.com/qualweb/qualweb.git",
     "directory": "packages/cui-checks"
   },
+  "bugs": {
+    "url": "https://github.com/qualweb/qualweb/issues"
+  },
   "author": "",
   "license": "ISC",
   "devDependencies": {

--- a/packages/earl-reporter/package.json
+++ b/packages/earl-reporter/package.json
@@ -26,7 +26,7 @@
   ],
   "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/earl-reporter",
   "bugs": {
-    "url": "https://github.com/qualweb/earl-reporter/issues",
+    "url": "https://github.com/qualweb/qualweb/issues",
     "email": "qualweb@fc.ul.pt"
   },
   "repository": {

--- a/packages/earl-reporter/package.json
+++ b/packages/earl-reporter/package.json
@@ -31,7 +31,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/qualweb/earl-reporter.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/earl-reporter"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/packages/earl-reporter/package.json
+++ b/packages/earl-reporter/package.json
@@ -24,7 +24,7 @@
     "report",
     "accessibility"
   ],
-  "homepage": "https://github.com/qualweb/earl-reporter#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/earl-reporter",
   "bugs": {
     "url": "https://github.com/qualweb/earl-reporter/issues",
     "email": "qualweb@fc.ul.pt"

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/qualweb/locale#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/locale.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/locale"
   },
   "bugs": {
     "url": "https://github.com/qualweb/locale/issues"

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -20,7 +20,7 @@
     "build": "tsc --build tsconfig.prod.json && webpack",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/locale#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/locale",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -27,7 +27,7 @@
     "directory": "packages/locale"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/locale/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "qualweb",

--- a/packages/qw-element/package.json
+++ b/packages/qw-element/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/qualweb/qw-element#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/qw-element.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/qw-element"
   },
   "bugs": {
     "url": "https://github.com/qualweb/qw-element/issues"

--- a/packages/qw-element/package.json
+++ b/packages/qw-element/package.json
@@ -24,7 +24,7 @@
     "directory": "packages/qw-element"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/qw-element/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "qualweb",

--- a/packages/qw-element/package.json
+++ b/packages/qw-element/package.json
@@ -17,7 +17,7 @@
     "docs": "typedoc --out docs src/index.ts",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/qw-element#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/locale",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/qw-page/package.json
+++ b/packages/qw-page/package.json
@@ -24,7 +24,7 @@
     "directory": "packages/qw-page"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/qw-page/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "qualweb",

--- a/packages/qw-page/package.json
+++ b/packages/qw-page/package.json
@@ -17,7 +17,7 @@
     "docs": "typedoc --out docs src/index.ts",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/qw-page#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/qw-page",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",

--- a/packages/qw-page/package.json
+++ b/packages/qw-page/package.json
@@ -20,7 +20,8 @@
   "homepage": "https://github.com/qualweb/qw-page#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/qw-page.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/qw-page"
   },
   "bugs": {
     "url": "https://github.com/qualweb/qw-page/issues"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/util",
   "bugs": {
-    "url": "https://github.com/qualweb/util/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "repository": {
     "type": "git",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -44,7 +44,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/util.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/util"
   },
   "keywords": [
     "qualweb",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -38,7 +38,7 @@
     "docs": "typedoc --out docs src/index.ts",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/util#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/util",
   "bugs": {
     "url": "https://github.com/qualweb/util/issues"
   },

--- a/packages/wcag-techniques/package.json
+++ b/packages/wcag-techniques/package.json
@@ -36,7 +36,8 @@
   "homepage": "https://github.com/qualweb/wcag-techniques#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/qualweb/wcag-techniques.git"
+    "url": "git+https://github.com/qualweb/qualweb.git",
+    "directory": "packages/wcag-techniques"
   },
   "bugs": {
     "url": "https://github.com/qualweb/wcag-techniques/issues"

--- a/packages/wcag-techniques/package.json
+++ b/packages/wcag-techniques/package.json
@@ -40,7 +40,7 @@
     "directory": "packages/wcag-techniques"
   },
   "bugs": {
-    "url": "https://github.com/qualweb/wcag-techniques/issues"
+    "url": "https://github.com/qualweb/qualweb/issues"
   },
   "keywords": [
     "wcag",

--- a/packages/wcag-techniques/package.json
+++ b/packages/wcag-techniques/package.json
@@ -33,7 +33,7 @@
     "build": "tsc --build tsconfig.prod.json && webpack",
     "prepublishOnly": "npm run build"
   },
-  "homepage": "https://github.com/qualweb/wcag-techniques#readme",
+  "homepage": "https://github.com/qualweb/qualweb/blob/main/packages/wcag-techniques",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git",


### PR DESCRIPTION
This addresses #225 

I went ahead and went through all the package.json files and updated any URLs that still pointed to the old separate repositories.

Not sure we actually need the "homepage" fields if they only point to the Github repo. On the other hand, I don't think it hurts, either :)