### PR TITLE
Build(deps): Bump franc-min from 5.0.0 to 6.2.1

### DIFF
--- a/.changeset/cool-bananas-behave.md
+++ b/.changeset/cool-bananas-behave.md
@@ -1,0 +1,5 @@
+---
+'@qualweb/util': patch
+---
+
+Build(deps): Bump franc-min from 5.0.0 to 6.2.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -5768,9 +5768,9 @@
       }
     },
     "node_modules/collapse-white-space": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-      "integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-2.1.0.tgz",
+      "integrity": "sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -8201,12 +8201,12 @@
       }
     },
     "node_modules/franc-min": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/franc-min/-/franc-min-5.0.0.tgz",
-      "integrity": "sha512-xy7Iq7uNflbvNU+bkyYWtP+BOHWZle7kT9GM84gEV14b7/7sgq7M7Flf6v1XRflHAuHoshBMveWA6Q+kEXYeHQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/franc-min/-/franc-min-6.2.0.tgz",
+      "integrity": "sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw==",
       "license": "MIT",
       "dependencies": {
-        "trigram-utils": "^1.0.0"
+        "trigram-utils": "^2.0.0"
       },
       "funding": {
         "type": "github",
@@ -10579,9 +10579,9 @@
       "license": "MIT"
     },
     "node_modules/n-gram": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-1.1.2.tgz",
-      "integrity": "sha512-mBTpWKp0NHdujHmxrskPg2jc108mjyMmVxHN1rZGK/ogTLi9O0debDIXlQPqotNELdNmVGtL4jr7SCig+4OWvQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/n-gram/-/n-gram-2.0.2.tgz",
+      "integrity": "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -13006,25 +13006,18 @@
       "license": "MIT"
     },
     "node_modules/trigram-utils": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-1.0.3.tgz",
-      "integrity": "sha512-UAhS1Ll21FtClVIzIN0I/SmGnJ+D08BOxX7Dl1penV8raC0ksf2dJkhNI6kU1Mj3uT86Bul12iMvxXquXSYSng==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/trigram-utils/-/trigram-utils-2.0.1.tgz",
+      "integrity": "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ==",
       "license": "MIT",
       "dependencies": {
-        "collapse-white-space": "^1.0.0",
-        "n-gram": "^1.0.0",
-        "trim": "0.0.1"
+        "collapse-white-space": "^2.0.0",
+        "n-gram": "^2.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==",
-      "deprecated": "Use String.prototype.trim() instead"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",
@@ -14459,7 +14452,7 @@
     },
     "packages/act-rules": {
       "name": "@qualweb/act-rules",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "ISC",
       "devDependencies": {
         "@qualweb/core": "^0.8.2",
@@ -14492,7 +14485,7 @@
     },
     "packages/best-practices": {
       "name": "@qualweb/best-practices",
-      "version": "0.7.3",
+      "version": "0.7.6",
       "license": "ISC",
       "devDependencies": {
         "@qualweb/core": "^0.8.2",
@@ -14522,11 +14515,11 @@
     },
     "packages/cli": {
       "name": "@qualweb/cli",
-      "version": "0.7.3",
+      "version": "0.7.7",
       "license": "ISC",
       "dependencies": {
-        "@qualweb/act-rules": "0.7.2",
-        "@qualweb/best-practices": "0.7.3",
+        "@qualweb/act-rules": "0.7.3",
+        "@qualweb/best-practices": "0.7.6",
         "@qualweb/core": "0.8.2",
         "@qualweb/counter": "0.3.2",
         "@qualweb/earl-reporter": "0.5.2",
@@ -14844,7 +14837,7 @@
       "version": "0.6.2",
       "license": "ISC",
       "dependencies": {
-        "franc-min": "5.0.0",
+        "franc-min": "^6.2.0",
         "string-pixel-width": "^1.10.0"
       },
       "devDependencies": {

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -77,7 +77,7 @@
     "webpack-cli": "^4.7.0"
   },
   "dependencies": {
-    "franc-min": "5.0.0",
+    "franc-min": "^6.2.0",
     "string-pixel-width": "^1.10.0"
   }
 }


### PR DESCRIPTION
Bump franc-min from 5.0.0 to 6.2.1 due to its dependency on vulnerable versions of trigram-utils

[https://github.com/advisories/GHSA-w5p7-h5w8-2hfq](https://github.com/advisories/GHSA-w5p7-h5w8-2hfq)

```
node_modules/trim
  trigram-utils  1.0.0 - 1.0.3
  Depends on vulnerable versions of trim
  node_modules/trigram-utils
    franc-min  3.1.1 - 5.0.0
    Depends on vulnerable versions of trigram-utils
    node_modules/franc-min
```