### PR TITLE
fix(exports): change exports in package.json file to work in projects with type module set

### DIFF
--- a/.changeset/clean-apples-warn.md
+++ b/.changeset/clean-apples-warn.md
@@ -1,0 +1,11 @@
+---
+'@qualweb/wcag-techniques': patch
+'@qualweb/best-practices': patch
+'@qualweb/cui-checks': patch
+'@qualweb/act-rules': patch
+'@qualweb/locale': patch
+'@qualweb/core': patch
+'@qualweb/util': patch
+---
+
+change package.json file export from "require" to "default" so it can work in projects that have "type": "module" set in package.json

--- a/packages/act-rules/package.json
+++ b/packages/act-rules/package.json
@@ -7,11 +7,11 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/__webpack/act.bundle.js",
+      "default": "./dist/__webpack/act.bundle.js",
       "types": "./dist/index.d.ts"
     },
     "./lib/*": {
-      "require": "./dist/lib/*"
+      "default": "./dist/lib/*"
     }
   },
   "scripts": {

--- a/packages/best-practices/package.json
+++ b/packages/best-practices/package.json
@@ -7,11 +7,11 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/__webpack/bp.bundle.js",
+      "default": "./dist/__webpack/bp.bundle.js",
       "types": "./dist/index.d.ts"
     },
     "./lib/*": {
-      "require": "./dist/lib/*"
+      "default": "./dist/lib/*"
     }
   },
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,23 +9,23 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js"
+      "default": "./dist/index.js"
     },
     "./evaluation": {
       "types": "./dist/lib/evaluation/index.d.ts",
-      "require": "./dist/lib/evaluation/index.js"
+      "default": "./dist/lib/evaluation/index.js"
     },
     "./evaluation/*": {
       "types": "./dist/lib/evaluation/*.d.ts",
-      "require": "./dist/lib/evaluation/*.js"
+      "default": "./dist/lib/evaluation/*.js"
     },
     "./lib": {
       "types": "./dist/lib/index.d.ts",
-      "require": "./dist/lib/index.js"
+      "default": "./dist/lib/index.js"
     },
     "./locale": {
       "types": "./dist/lib/i18n/index.d.ts",
-      "require": "./dist/lib/i18n/index.js"
+      "default": "./dist/lib/i18n/index.js"
     }
   },
   "scripts": {

--- a/packages/cui-checks/package.json
+++ b/packages/cui-checks/package.json
@@ -7,14 +7,14 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/__webpack/cui.bundle.js",
+      "default": "./dist/__webpack/cui.bundle.js",
       "types": "./dist/index.d.ts"
     },
     "./lib/*": {
-      "require": "./dist/lib/*"
+      "default": "./dist/lib/*"
     },
     "./CuiChecksModule": {
-      "require": "./dist/CuiChecksModule.js",
+      "default": "./dist/CuiChecksModule.js",
       "types": "./dist/CuiChecksModule.d.ts"
     }
   },

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -7,7 +7,7 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/locale.bundle.js",
+      "default": "./dist/locale.bundle.js",
       "types": "./prebuild/index.d.ts"
     }
   },

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -8,19 +8,19 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/__webpack/util.bundle.js",
+      "default": "./dist/__webpack/util.bundle.js",
       "types": "./dist/index.d.ts"
     },
     "./applicability": {
-      "require": "./dist/applicability/applicability.js",
+      "default": "./dist/applicability/applicability.js",
       "types": "./dist/applicability/applicability.d.ts"
     },
     "./accessibilityUtils": {
-      "require": "./dist/accessibilityUtils/accessibilityUtils.js",
+      "default": "./dist/accessibilityUtils/accessibilityUtils.js",
       "types": "./dist/accessibilityUtils/accessibilityUtils.d.ts"
     },
     "./domUtils": {
-      "require": "./dist/domUtils/domUtils.js",
+      "default": "./dist/domUtils/domUtils.js",
       "types": "./dist/domUtils/domUtils.d.ts"
     }
   },

--- a/packages/wcag-techniques/package.json
+++ b/packages/wcag-techniques/package.json
@@ -7,14 +7,14 @@
   ],
   "exports": {
     ".": {
-      "require": "./dist/__webpack/wcag.bundle.js",
+      "default": "./dist/__webpack/wcag.bundle.js",
       "types": "./dist/index.d.ts"
     },
     "./lib/*": {
-      "require": "./dist/lib/*"
+      "default": "./dist/lib/*"
     },
     "./WcagTechniquesModule": {
-      "require": "./dist/WcagTechniquesModule.js",
+      "default": "./dist/WcagTechniquesModule.js",
       "types": "./dist/WcagTechniquesModule.d.ts"
     }
   },


### PR DESCRIPTION
Change package.json file export from `"require"` to `"default"` so it can work in projects that have `"type": "module"` set in package.json

This PR should resolve #252.