### PR TITLE
ACT-R30 - Disregard text of hidden children

### DIFF
--- a/.changeset/strict-forks-pay.md
+++ b/.changeset/strict-forks-pay.md
@@ -1,0 +1,6 @@
+---
+'@qualweb/act-rules': minor
+'@qualweb/util': minor
+---
+
+adds getVisibleText function for use in ACT-R30. Compared to the getTrimmedText function this wanders down the tree and looks recursively for a visible element. Whereas the getTrimmedText function merely get's the text of the apparent element.

--- a/packages/act-rules/src/rules/QW-ACT-R30.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R30.ts
@@ -12,7 +12,7 @@ class QW_ACT_R30 extends AtomicRule {
     const test = new Test();
 
     const accessibleName = window.AccessibilityUtils.getAccessibleName(element);
-    const elementText = window.DomUtils.getTrimmedText(element);
+    const elementText = window.DomUtils.getVisibleText(element);
     const isIconValue = this.isIcon(elementText, accessibleName, element);
 
     if (accessibleName === undefined) {

--- a/packages/util/src/domUtils/domUtils.ts
+++ b/packages/util/src/domUtils/domUtils.ts
@@ -15,6 +15,7 @@ import getTrimmedTextFunction from './getTrimmedText';
 import objectElementIsNonTextFunction from './objectElementIsNonText';
 import isHumanLanguageFunction from './isHumanLanguage';
 import getTextSizeFunction from './getTextSize';
+import getVisibleTextFunction from './getVisibleText';
 
 import { Cache, FullMethodCache } from '../cache';
 
@@ -80,6 +81,10 @@ class DomUtils {
   @Cache('DomUtils.getTrimmedText')
   public static getTrimmedText(element: QWElement): string {
     return getTrimmedTextFunction(element);
+  }
+  @Cache('DomUtils.getVisibleText')
+  public static getVisibleText(element: QWElement): string {
+    return getVisibleTextFunction(element);
   }
 }
 

--- a/packages/util/src/domUtils/getVisibleText.ts
+++ b/packages/util/src/domUtils/getVisibleText.ts
@@ -1,0 +1,21 @@
+import type { QWElement } from '@qualweb/qw-element';
+
+function getVisibleText(element: QWElement): string {
+  const children = element.getElementChildren();
+  let text = '';
+
+  if (children.length === 0) {
+    text = element.getElementText();
+  }
+  else {
+    for (const child of children) {
+      if (window.DomUtils.isElementVisible(child)) {
+        text += ' ' + getVisibleText(child);
+      }
+    }
+  }
+
+  return text ? text.trim() : '';
+}
+
+export default getVisibleText;


### PR DESCRIPTION
We had a lot of false ACT-R30 positives from a website vendor and their search element implementation.
ex. https://24-7.herning.dk/

This allows us to dig deeper into the tree of a parent element and get the actual text and not return early when there is no immediate sign of textual content.

@annethyme can provide further context.