### PR TITLE
Fix ACT rule test-case failures (R16, R38, R44)

### DIFF
--- a/.changeset/little-cooks-relax.md
+++ b/.changeset/little-cooks-relax.md
@@ -1,0 +1,6 @@
+---
+"@qualweb/util": patch
+"@qualweb/act-rules": patch
+---
+
+Fix ACT rule test-case failures (R16, R38, R44)

--- a/packages/act-rules/src/lib/mapping.ts
+++ b/packages/act-rules/src/lib/mapping.ts
@@ -10,7 +10,7 @@ export default {
   meta: ['QW-ACT-R4', 'QW-ACT-R71'],
   svg: ['QW-ACT-R21'],
   'body *[lang]': ['QW-ACT-R22'],
-  '[role="row"],[role="list"],[role="menu"],[role="menubar"],[role="listbox"],[role="grid"],[role="rowgroup"],[role="table"],[role="treegrid"],[role="tablist"]':
+  '[role="row"],[role="list"],[role="menu"],[role="menubar"],[role="listbox"],[role="grid"],[role="rowgroup"],[role="table"],[role="treegrid"],[role="tablist"],ul,ol,menu,table,tr,thead,tbody,tfoot,datalist':
     ['QW-ACT-R38'],
   body: ['QW-ACT-R62', 'QW-ACT-R9', 'QW-ACT-R10', 'QW-ACT-R25', 'QW-ACT-R27', 'QW-ACT-R28', 'QW-ACT-R34', 'QW-ACT-R44'],
   'input, select, textarea, [role]': ['QW-ACT-R16', 'QW-ACT-R41'],

--- a/packages/act-rules/src/lib/rules.json
+++ b/packages/act-rules/src/lib/rules.json
@@ -820,7 +820,7 @@
     "name": "ARIA required owned elements",
     "code": "QW-ACT-R38",
     "mapping": "bc4a75",
-    "description": "This rule checks that an element with an explicit semantic role has at least one of its required owned elements.",
+    "description": "This rule checks that an element with a semantic role that has required owned elements owns at least one of those required owned elements.",
     "metadata": {
       "target": {
         "element": "*",

--- a/packages/act-rules/src/rules/QW-ACT-R16.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R16.ts
@@ -1,25 +1,53 @@
 import type { QWElement } from '@qualweb/qw-element';
-import { ElementExists, ElementHasOneOfTheFollowingRoles, ElementIsInAccessibilityTree } from '@qualweb/util/applicability';
+import { ElementExists, ElementIsInAccessibilityTree } from '@qualweb/util/applicability';
 import { Test, Verdict } from '@qualweb/core/evaluation';
 import { AtomicRule } from '../lib/AtomicRule.object';
 
+// Semantic roles that make a form field applicable to this rule.
+const applicableRoles = [
+  'checkbox',
+  'combobox',
+  'listbox',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'radio',
+  'searchbox',
+  'slider',
+  'spinbutton',
+  'switch',
+  'textbox'
+];
+
+// Input types that have no semantic role but still require an accessible name.
+const applicableInputTypes = [
+  'color',
+  'date',
+  'datetime-local',
+  'file',
+  'month',
+  'password',
+  'time',
+  'week'
+];
+
 class QW_ACT_R16 extends AtomicRule {
   @ElementExists
-  @ElementHasOneOfTheFollowingRoles([
-    'checkbox',
-    'combobox',
-    'listbox',
-    'menuitemcheckbox',
-    'menuitemradio',
-    'radio',
-    'searchbox',
-    'slider',
-    'spinbutton',
-    'switch',
-    'textbox'
-  ])
   @ElementIsInAccessibilityTree
   execute(element: QWElement): void {
+    const role = window.AccessibilityUtils.getElementRole(element);
+
+    // Applicable if the element has one of the applicable semantic roles, or if
+    // it is an input with no semantic role and one of the applicable types.
+    const applicableByRole = !!role && applicableRoles.includes(role);
+    const applicableByInputType =
+      !role &&
+      element.getElementTagName() === 'input' &&
+      applicableInputTypes.includes((element.getElementAttribute('type') ?? '').toLowerCase());
+
+    if (!applicableByRole && !applicableByInputType) {
+      return;
+    }
+
     const test = new Test();
 
     const accessibleName = window.AccessibilityUtils.getAccessibleName(element);

--- a/packages/act-rules/src/rules/QW-ACT-R38.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R38.ts
@@ -15,13 +15,16 @@ class QW_ACT_R38 extends AtomicRule {
     const rolesJSON = window.AccessibilityUtils.roles;
     const test = new Test();
 
-    const explicitRole = element.getElementAttribute('role');
-    const implicitRole = window.AccessibilityUtils.getImplicitRole(element, ''); //fixme
+    // The rule applies to any element (implicit or explicit role) whose
+    // semantic role defines required owned elements, unless it has an inclusive
+    // ancestor with aria-busy="true".
+    const role = window.AccessibilityUtils.getElementRole(element);
+    const requiredOwnedElements = role ? rolesJSON[role]?.['requiredOwnedElements'] : undefined;
     const ariaBusy = this.isElementADescendantOfAriaBusy(element) || element.getElementAttribute('aria-busy');
 
-    if (explicitRole !== null && explicitRole !== implicitRole && explicitRole !== 'combobox' && !ariaBusy) {
+    if (requiredOwnedElements && requiredOwnedElements.length > 0 && !ariaBusy) {
       const result = this.checkOwnedElementsRole(
-        rolesJSON[explicitRole]['requiredOwnedElements'],
+        requiredOwnedElements,
         window.AccessibilityUtils.getOwnedElements(element)
       );
 

--- a/packages/util/src/accessibilityUtils/getLinkContext.ts
+++ b/packages/util/src/accessibilityUtils/getLinkContext.ts
@@ -1,5 +1,9 @@
 import type { QWElement } from '@qualweb/qw-element';
 
+// Two links have the "same programmatically determined link context" when the
+// context elements convey the same text - not when they are the same DOM node.
+// So the context is keyed by the normalized text of each context element rather
+// than by its (necessarily unique) CSS selector.
 //incomplete
 //ignores being a header cell assigned to the closest ancestor of the link in the flat tree that has a semantic role of cell or gridcell;
 function getLinkContext(element: QWElement): Array<string> {
@@ -9,20 +13,7 @@ function getLinkContext(element: QWElement): Array<string> {
   let ariaDescribedBy = new Array<string>();
   if (ariaDescribedByATT) ariaDescribedBy = ariaDescribedByATT.split(' ');
   if (parent) {
-    const role = window.AccessibilityUtils.getElementRole(parent);
-    const inAT = window.AccessibilityUtils.isElementInAT(parent);
-    const tagName = parent.getElementTagName();
-    const id = parent.getElementAttribute('id');
-    if (
-      inAT &&
-      (tagName === 'p' ||
-        role === 'cell' ||
-        role === 'gridcell' ||
-        role === 'listitem' ||
-        (id && ariaDescribedBy.includes(id)))
-    ) {
-      context.push(parent.getElementSelector());
-    }
+    addContext(parent, ariaDescribedBy, context);
     getLinkContextAux(parent, ariaDescribedBy, context);
   }
   return context;
@@ -31,21 +22,25 @@ function getLinkContext(element: QWElement): Array<string> {
 function getLinkContextAux(element: QWElement, ariaDescribedBy: Array<string>, context: Array<string>): void {
   const parent = element.getElementParent();
   if (parent) {
-    const role = window.AccessibilityUtils.getElementRole(parent);
-    const inAT = window.AccessibilityUtils.isElementInAT(parent); //isElementInAT(when added html list)
-    const tagName = parent.getElementTagName();
-    const id = parent.getElementAttribute('id');
-    if (
-      inAT &&
-      (tagName === 'p' ||
-        role === 'cell' ||
-        role === 'gridcell' ||
-        role === 'listitem' ||
-        (id && ariaDescribedBy.includes(id)))
-    ) {
-      context.push(parent.getElementSelector());
-    }
+    addContext(parent, ariaDescribedBy, context);
     getLinkContextAux(parent, ariaDescribedBy, context);
+  }
+}
+
+function addContext(parent: QWElement, ariaDescribedBy: Array<string>, context: Array<string>): void {
+  const role = window.AccessibilityUtils.getElementRole(parent);
+  const inAT = window.AccessibilityUtils.isElementInAT(parent);
+  const tagName = parent.getElementTagName();
+  const id = parent.getElementAttribute('id');
+  if (
+    inAT &&
+    (tagName === 'p' ||
+      role === 'cell' ||
+      role === 'gridcell' ||
+      role === 'listitem' ||
+      (id && ariaDescribedBy.includes(id)))
+  ) {
+    context.push((parent.getElementText() ?? '').replace(/\s+/g, ' ').trim());
   }
 }
 


### PR DESCRIPTION
Fixes three ACT rule implementations that were failing their W3C/ACT-R test cases against the proposed rule versions in `testcases.json`.

## QW-ACT-R16 — Form field has non-empty accessible name (`e086e5`)
The proposed rule extends applicability beyond the listed semantic roles to inputs that have **no** semantic role but a `type` of `color`, `date`, `datetime-local`, `file`, `month`, `password`, `time`, or `week`. These still require a non-empty accessible name. Previously `<input type="date">` (Failed Example 9) was `inapplicable` instead of `failed`. Applicability is now computed in `execute()` to cover both the role list and the roleless input types.

## QW-ACT-R38 — ARIA required owned elements (`bc4a75`)
The proposed rule applies to any element in the accessibility tree whose semantic role has required owned elements — **implicit** roles included, not only explicit `role` attributes. `<ul>` with non-`listitem` children (Failed Example 10) was `inapplicable` instead of `failed`.
- Broadened `execute()` to use the element's effective role (`getElementRole`) and act whenever that role defines required owned elements (this also makes the old `combobox` special-case redundant).
- Extended the mapping selector to include native elements whose implicit role has required owned elements (`ul, ol, menu, table, tr, thead, tbody, tfoot, datalist`).
- Updated the rule description.

## QW-ACT-R44 — Links with identical accessible names and same context (`fd3a94`)
Two links share "the same programmatically determined link context" when the context elements convey the same **text**, not when they are the same DOM node. `getLinkContext` keyed the context by each element's unique CSS selector, so identical-text links in separate paragraphs (Failed Example 2) were never grouped and the rule was `inapplicable`. The context is now keyed by the normalized text of each context element. (Change lives in `packages/util`; `getLinkContext` is used only by R44.)

## Verification
All test cases pass for each affected rule: R16 (22/22), R38 (24/24), R44 (24/24), with no regressions within those suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)