### PR TITLE
Fix test harness so media rules (QW-ACT-R49/R50) load media

### DIFF
--- a/packages/act-rules/test/rule.spec.ts
+++ b/packages/act-rules/test/rule.spec.ts
@@ -150,16 +150,77 @@ describe('ACT rules', () => {
           // Script injection doesn't work on non-HTML pages. Instead, we insert
           // some empty HTML stuff and let the rule take over from there.
           //
-          // For HTML pages, use the already-fetched source rather than
-          // navigating Chromium to the W3C URL. Browser navigation can be served
-          // an anti-bot verification page, while node-fetch receives the actual
-          // testcase HTML.
+          // For HTML pages, navigate Chromium to the real testcase URL but
+          // intercept requests. The top-level document is fulfilled with the
+          // already node-fetched source (browser navigation can be served an
+          // anti-bot verification page, while node-fetch receives the actual
+          // testcase HTML). Loading at the real origin means relative asset URLs
+          // resolve naturally and same-origin media is not blocked. Other
+          // requests to the W3C host are proxied through node-fetch as well,
+          // because Cloudflare serves headless Chromium a 403 for media assets
+          // that node-fetch retrieves fine. Media-related rules (e.g. QW-ACT-R49,
+          // QW-ACT-R50) read runtime properties such as `duration` and decoded
+          // audio bytes, which are only populated once the media actually loads.
           if (test.url.endsWith('html')) {
-            const sourceHtmlWithBase = sourceHtml.replace(
-              /<head([^>]*)>/i,
-              `<head$1><base href="${test.url}">`
-            );
-            await page.setContent(sourceHtmlWithBase, { waitUntil: 'networkidle2' });
+            await page.setRequestInterception(true);
+            let mainDocumentServed = false;
+            page.on('request', async (request) => {
+              try {
+                if (
+                  !mainDocumentServed &&
+                  request.isNavigationRequest() &&
+                  request.frame() === page.mainFrame()
+                ) {
+                  mainDocumentServed = true;
+                  return await request.respond({
+                    status: 200,
+                    contentType: 'text/html; charset=utf-8',
+                    body: sourceHtml
+                  });
+                }
+
+                if (/^https?:\/\/[^/]*\bw3\.org\//.test(request.url())) {
+                  const assetResponse = await fetch(request.url());
+                  return await request.respond({
+                    status: assetResponse.status,
+                    contentType: assetResponse.headers.get('content-type') ?? undefined,
+                    body: await assetResponse.buffer()
+                  });
+                }
+
+                return await request.continue();
+              } catch {
+                try {
+                  await request.continue();
+                } catch {
+                  // Request was already handled or the page is closing.
+                }
+              }
+            });
+
+            await page.goto(test.url, { waitUntil: 'networkidle2' });
+
+            // Give any media elements a chance to load their metadata (and decode
+            // enough audio for detection) before the rule reads their properties.
+            // NOTE: this evaluated function must not use async/await - it is
+            // serialised into the browser, where the transpiler's `__awaiter`
+            // helper is undefined. Return a Promise instead.
+            await page.evaluate(() => {
+              const mediaElements = Array.from(document.querySelectorAll('video, audio'));
+              return Promise.all(
+                mediaElements.map(
+                  (element) =>
+                    new Promise<void>((resolve) => {
+                      if ((element as HTMLMediaElement).readyState >= 1) {
+                        resolve();
+                        return;
+                      }
+                      element.addEventListener('loadedmetadata', () => resolve(), { once: true });
+                      setTimeout(() => resolve(), 5000);
+                    })
+                )
+              );
+            });
           } else {
             await page.setContent('<!DOCTYPE html><html nonHTMLPage=true><body>Empty</body></html>', { waitUntil: 'networkidle2' });
           }


### PR DESCRIPTION
## Problem

The QW-ACT-R49 and QW-ACT-R50 tests were failing — every "Failed Example" returned `inapplicable` instead of `failed`/`cantTell`:

```
AssertionError: expected 'inapplicable' to be one of [ 'failed', 'cantTell' ]
```

## Root cause

This is a **test-harness** issue, not a rule bug. Both rules read *runtime* media properties to determine applicability:

- `duration > 3` (`getElementProperty('duration')`)
- audio presence via `webkitAudioDecodedByteCount > 120`

These are only populated once the `<audio>`/`<video>` actually loads and decodes. The harness loaded testcases with `page.setContent(...)` + a `<base>` tag, which serves the document from a synthetic `about:blank` origin. That made the W3C media assets **cross-origin**, so Chromium blocked them (`ERR_BLOCKED_BY_RESPONSE.NotSameOrigin`). Serving at the real origin instead produced a Cloudflare **403** for headless Chromium (node-fetch/curl get 200). With no media loaded, `duration` was `NaN`, so `duration > 3` was false and both rules returned **inapplicable**.

## Fix

For HTML testcases, navigate to the real URL with request interception that:

1. fulfills the top-level document from the already node-fetched HTML (still dodges the anti-bot verification page — the original reason for `setContent`),
2. proxies other `w3.org` asset requests through node-fetch (dodges Cloudflare's 403 on media), and
3. waits for media metadata to load before running the rule.

**No rule logic was changed.**

## Verification

- **R49 + R50: 18/18 passing** (previously 7 failing).
- Regression sample — media rules R15/R48/R51 + text rules R1/R11/R16: **77/77 passing**, no regressions.
- Type-check clean on the modified file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)