### PR TITLE
Fix QW-ACT-R30 whitespace normalization regex

### DIFF
--- a/.changeset/act-r30-whitespace-regex.md
+++ b/.changeset/act-r30-whitespace-regex.md
@@ -1,0 +1,5 @@
+---
+"@qualweb/act-rules": patch
+---
+
+Fix whitespace normalization in QW-ACT-R30 (`2ee8b8`). The `includesText` helper used `/s+/g`, which matches the literal letter "s" instead of whitespace. It is now `/\s+/g`, so runs of whitespace in the accessible name and visible text are correctly collapsed before comparison (e.g. a label such as `"  ACT   rules  "` now matches `"ACT rules"`).

--- a/packages/act-rules/src/rules/QW-ACT-R30.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R30.ts
@@ -44,12 +44,12 @@ class QW_ACT_R30 extends AtomicRule {
       .toLowerCase()
       .trim()
       .replace(/\r?\n|\r|[^\w\s-]+/g, '')
-      .replace(/s+/g, ' ');
+      .replace(/\s+/g, ' ');
     elementText = elementText
       .toLowerCase()
       .trim()
       .replace(/\r?\n|\r|[^\w\s-]+/g, '')
-      .replace(/s+/g, ' ');
+      .replace(/\s+/g, ' ');
     return accessibleName.includes(elementText);
   }
 }


### PR DESCRIPTION
## Summary

`QW-ACT-R30` (ACT rule `2ee8b8`, *Visible label is part of accessible name*) normalizes the accessible name and visible text before comparing them. The final normalization step used `/s+/g`, which matches the **literal letter "s"** rather than whitespace (`\s`). This meant runs of whitespace were never collapsed, so labels with irregular internal spacing (e.g. `aria-label="  ACT   rules  "` vs. visible `ACT rules`) failed to match.

This changes both occurrences to `/\s+/g`.

```diff
-      .replace(/s+/g, ' ');
+      .replace(/\s+/g, ' ');
```

## Verification

- All **15 published** `2ee8b8` test cases still pass (`npm run test:rule -- --grep QW-ACT-R30`) — no regression.
- Confirmed the fix collapses multi-whitespace labels correctly (previously-failing multi-space inputs now match).

## Scope note

This is the isolated, safe correctness fix. A separate, larger effort would be needed to align QW-ACT-R30 with the **unpublished** rewrite of `2ee8b8` on `w3c/wcag-act-rules@main` (a new formal Label-in-Name algorithm with different applicability and, in some cases, flipped expected outcomes). That is intentionally **out of scope** here — the repo remains conformant with the currently published rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)