### PR TITLE
Cross-driver ACT rules parity test (the follow-up promised in #316) + ESM exports fix

### DIFF
--- a/.changeset/esm-default-export-condition.md
+++ b/.changeset/esm-default-export-condition.md
@@ -1,0 +1,10 @@
+---
+"@qualweb/act-rules": patch
+"@qualweb/wcag-techniques": patch
+"@qualweb/best-practices": patch
+"@qualweb/cui-checks": patch
+"@qualweb/locale": patch
+"@qualweb/util": patch
+---
+
+Add a `default` condition to the `exports` map so the packages resolve from ES modules. Previously only a `require` condition was defined, so any `import` of these packages (including Node's own `require(esm)`/type-stripping paths on Node >= 22) failed with `ERR_PACKAGE_PATH_NOT_EXPORTED`. Note that the bundles remain CommonJS: named exports are not statically analyzable, so ESM consumers reach them through the default export (`import pkg from '@qualweb/act-rules'; pkg.ACTRules`).

--- a/packages/act-rules/package.json
+++ b/packages/act-rules/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/__webpack/act.bundle.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/__webpack/act.bundle.js"
     },
     "./lib/*": {
       "require": "./dist/lib/*"

--- a/packages/best-practices/package.json
+++ b/packages/best-practices/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/__webpack/bp.bundle.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/__webpack/bp.bundle.js"
     },
     "./lib/*": {
       "require": "./dist/lib/*"

--- a/packages/cui-checks/package.json
+++ b/packages/cui-checks/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/__webpack/cui.bundle.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/__webpack/cui.bundle.js"
     },
     "./lib/*": {
       "require": "./dist/lib/*"

--- a/packages/locale/package.json
+++ b/packages/locale/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/locale.bundle.js",
-      "types": "./prebuild/index.d.ts"
+      "types": "./prebuild/index.d.ts",
+      "default": "./dist/locale.bundle.js"
     }
   },
   "scripts": {

--- a/packages/playwright-driver/package.json
+++ b/packages/playwright-driver/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@koa/router": "^12.0.1",
+    "@qualweb/act-rules": "0.8.3",
     "@qualweb/core": "^0.9.0",
     "@qualweb/locale": "0.2.2",
     "@tsconfig/recommended": "^1.0.3",

--- a/packages/playwright-driver/test/parity.spec.ts
+++ b/packages/playwright-driver/test/parity.spec.ts
@@ -1,0 +1,146 @@
+import { expect } from 'chai';
+import { Server } from 'http';
+import { QualWeb } from '@qualweb/core';
+import type { QualwebReport, EvaluationReport } from '@qualweb/core/evaluation';
+import * as actRulesInterop from '@qualweb/act-rules';
+import { PlaywrightDriver } from '../src';
+import { createFixtureServer, listen } from './util';
+
+// The act-rules package is a CommonJS webpack bundle whose named exports
+// cannot be statically detected. When this spec is loaded as CommonJS
+// (ts-node), the namespace import holds the exports directly; when it is
+// loaded as native ESM (mocha `import()`s specs, which works for TypeScript
+// on Node >= 22.6), they are only reachable through the synthetic default
+// export.
+const { ACTRules } = (actRulesInterop as { default?: typeof actRulesInterop }).default ?? actRulesInterop;
+
+/**
+ * Cross-driver parity: runs the real ACT rules module (in-page bundles and
+ * all) against the same fixture page under the default Puppeteer driver and
+ * under the Playwright driver, then compares the reports rule by rule.
+ *
+ * The fixture page (`/act-parity`) contains deliberate, deterministic passes
+ * and failures so the comparison is meaningful - a page where every rule is
+ * inapplicable would vacuously "match" under any two drivers.
+ */
+describe('Cross-driver parity (ACT rules)', function () {
+  // Two full ACT evaluations, including the mid-evaluation viewport resize
+  // for the special-case rules.
+  this.timeout(5 * 60 * 1000);
+
+  let server: Server;
+  let puppeteerAct: EvaluationReport;
+  let playwrightAct: EvaluationReport;
+
+  async function evaluateWith(driver: PlaywrightDriver | undefined, url: string): Promise<QualwebReport> {
+    const qualweb = new QualWeb(undefined, driver);
+    await qualweb.start();
+    try {
+      const reports = await qualweb.evaluate({
+        url,
+        // Pin the viewport so both drivers render the page identically
+        // regardless of their default window sizes.
+        viewport: { resolution: { width: 1366, height: 768 } },
+        log: { console: false },
+        modules: [new ACTRules()]
+      });
+      return reports[url];
+    } finally {
+      await qualweb.stop();
+    }
+  }
+
+  before(async function () {
+    const { server: fixtureServer, host } = await listen(createFixtureServer());
+    server = fixtureServer;
+    const url = `${host}/act-parity`;
+
+    const puppeteerReport = await evaluateWith(undefined, url);
+    const playwrightReport = await evaluateWith(new PlaywrightDriver(), url);
+
+    expect(puppeteerReport?.modules['act-rules'], 'puppeteer act-rules report').to.not.be.undefined;
+    expect(playwrightReport?.modules['act-rules'], 'playwright act-rules report').to.not.be.undefined;
+
+    puppeteerAct = puppeteerReport.modules['act-rules']!;
+    playwrightAct = playwrightReport.modules['act-rules']!;
+  });
+
+  after(() => {
+    server?.close();
+  });
+
+  it('Should exercise the fixture meaningfully (sanity check)', function () {
+    const outcomes = Object.values(puppeteerAct.assertions).map((assertion) => assertion.metadata.outcome);
+
+    expect(Object.keys(puppeteerAct.assertions).length).to.be.greaterThan(50);
+    expect(outcomes.filter((outcome) => outcome === 'failed').length, 'failed rules').to.be.greaterThanOrEqual(3);
+    expect(outcomes.filter((outcome) => outcome === 'passed').length, 'passed rules').to.be.greaterThanOrEqual(3);
+
+    // The image without alt text is the most stable failure in the fixture.
+    expect(puppeteerAct.assertions['QW-ACT-R17']?.metadata.outcome).to.equal('failed');
+  });
+
+  it('Should evaluate the same set of rules under both drivers', function () {
+    expect(Object.keys(playwrightAct.assertions).sort()).to.deep.equal(Object.keys(puppeteerAct.assertions).sort());
+  });
+
+  it('Should reach the same outcome for every rule', function () {
+    const mismatches: Record<string, { puppeteer?: string; playwright?: string }> = {};
+
+    for (const [rule, assertion] of Object.entries(puppeteerAct.assertions)) {
+      const other = playwrightAct.assertions[rule];
+      if (assertion.metadata.outcome !== other?.metadata.outcome) {
+        mismatches[rule] = {
+          puppeteer: assertion.metadata.outcome,
+          playwright: other?.metadata.outcome
+        };
+      }
+    }
+
+    expect(mismatches).to.deep.equal({});
+  });
+
+  it('Should produce the same verdict counts for every rule', function () {
+    type Counts = { passed: number; warning: number; failed: number; inapplicable: number };
+    const mismatches: Record<string, { puppeteer: Counts; playwright: Counts }> = {};
+
+    const countsOf = (report: EvaluationReport, rule: string): Counts => ({
+      passed: report.assertions[rule]?.metadata.passed ?? -1,
+      warning: report.assertions[rule]?.metadata.warning ?? -1,
+      failed: report.assertions[rule]?.metadata.failed ?? -1,
+      inapplicable: report.assertions[rule]?.metadata.inapplicable ?? -1
+    });
+
+    for (const rule of Object.keys(puppeteerAct.assertions)) {
+      const puppeteerCounts = countsOf(puppeteerAct, rule);
+      const playwrightCounts = countsOf(playwrightAct, rule);
+      if (JSON.stringify(puppeteerCounts) !== JSON.stringify(playwrightCounts)) {
+        mismatches[rule] = { puppeteer: puppeteerCounts, playwright: playwrightCounts };
+      }
+    }
+
+    expect(mismatches).to.deep.equal({});
+  });
+
+  it('Should flag the same elements for failed rules', function () {
+    const failedElements = (report: EvaluationReport): Record<string, string[]> => {
+      const byRule: Record<string, string[]> = {};
+      for (const [rule, assertion] of Object.entries(report.assertions)) {
+        if (assertion.metadata.outcome !== 'failed') {
+          continue;
+        }
+        byRule[rule] = assertion.results
+          .filter((result) => result.verdict === 'failed')
+          .flatMap((result) => result.elements.map((element) => `${result.resultCode}|${element.pointer ?? ''}`))
+          .sort();
+      }
+      return byRule;
+    };
+
+    expect(failedElements(playwrightAct)).to.deep.equal(failedElements(puppeteerAct));
+  });
+
+  it('Should agree on the module-level totals', function () {
+    expect(playwrightAct.metadata).to.deep.equal(puppeteerAct.metadata);
+  });
+});

--- a/packages/playwright-driver/test/util.ts
+++ b/packages/playwright-driver/test/util.ts
@@ -7,7 +7,13 @@ import Koa from 'koa';
  * - `/child` - a linked page
  * - `/dialog` - a page that fires alert() on load
  * - `/popup` - a page that window.open()s a second tab on load
+ * - `/act-parity` - a page with deliberate, deterministic ACT rule passes and
+ *   failures, used by the cross-driver parity test
  */
+// 1x1 red PNG, inlined so image requests never depend on the network.
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
 export function createFixtureServer(): Koa {
   const app = new Koa();
 
@@ -51,6 +57,31 @@ export function createFixtureServer(): Koa {
             <body>
               <h1>Popup</h1>
               <script>window.open('/child');</script>
+            </body>
+          </html>`;
+        break;
+      case '/act-parity':
+        ctx.body = `<!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <title>ACT parity fixture</title>
+              <meta name="viewport" content="width=device-width, initial-scale=1">
+              <style>
+                .low-contrast { color: #cccccc; background-color: #ffffff; }
+                .high-contrast { color: #000000; background-color: #ffffff; }
+              </style>
+            </head>
+            <body>
+              <h1>Parity fixture</h1>
+              <h2></h2>
+              <img src="${TINY_PNG}" alt="A red dot">
+              <img src="${TINY_PNG}">
+              <button></button>
+              <button>Submit</button>
+              <a href="/child">child page</a>
+              <a href="/child"></a>
+              <p class="low-contrast">This text has deliberately poor contrast.</p>
+              <p class="high-contrast">This text has deliberately good contrast.</p>
             </body>
           </html>`;
         break;

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "require": "./dist/__webpack/util.bundle.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/__webpack/util.bundle.js"
     },
     "./applicability": {
       "require": "./dist/applicability/applicability.js",

--- a/packages/wcag-techniques/package.json
+++ b/packages/wcag-techniques/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "require": "./dist/__webpack/wcag.bundle.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/__webpack/wcag.bundle.js"
     },
     "./lib/*": {
       "require": "./dist/lib/*"


### PR DESCRIPTION
## What

Two related changes, one commit each:

### 1. `fix(exports)`: add a `default` condition to the module packages' exports maps (fixes #331)

`@qualweb/act-rules`, `@qualweb/wcag-techniques`, `@qualweb/best-practices`, `@qualweb/cui-checks`, `@qualweb/locale` and `@qualweb/util` declared only a `require` condition, so importing them from any ES-module context failed with `ERR_PACKAGE_PATH_NOT_EXPORTED` (details and repro in #331). The `default` condition points at the same CJS bundle; `require` resolution is untouched. Changeset included (patch for all six).

The parity test below is how we hit this: on Node >= 22.6, mocha loads `.ts` specs via `import()` (native type stripping) before falling back to `require`/ts-node, and the spec imports `@qualweb/act-rules` Node-side. The test also guards its import for both loader modes, since the webpack bundles' named exports are not statically analyzable from ESM.

### 2. `test(playwright-driver)`: the real-module cross-driver comparison test promised in #316

PR #319 shipped with a known gap, noted in its description: the driver tests used a `DummyModule`, because in-page bundle injection could not run from a fresh checkout until the `qw-page`/`util` build issues (#312) were fixed. #312 is fixed and #318/#319 are merged, so here is the promised test.

`test/parity.spec.ts` runs the **real ACT rules module** — bundle injection, in-page execution, and the mid-evaluation viewport resize for the special-case rules — against the same fixture page under the default Puppeteer driver and under the Playwright driver, then compares the two reports:

- same set of evaluated rules;
- same outcome for every rule;
- same passed/warning/failed/inapplicable counts for every rule;
- same flagged elements (resultCode + pointer) for every failed rule;
- same module-level totals;
- plus a sanity check that the fixture actually produces failures and passes (a page where every rule is inapplicable would vacuously "match").

The new `/act-parity` fixture page contains deliberate, deterministic passes and failures (missing/present img alt, named/unnamed buttons and links, empty heading, low/high contrast text), and the evaluation pins the viewport so both drivers render identically regardless of their default window sizes.

## Testing

- `npm -w @qualweb/playwright-driver test`: 18 passing (12 existing driver tests + 6 parity tests).
- Verified under both spec-loader modes on Node 24 (native-ESM `import()` and ts-node CJS via `--no-experimental-strip-types`); CI's Node 20 uses the ts-node path.
- `npm -ws run build` and `tsc --noEmit` for the touched package are clean; the six exports-map changes alter no `require` behavior (their own suites resolve via `require` as before).

Closes the follow-up promised in #316; fixes #331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)