### PR TITLE
fix(playwright-driver): keep the loaded document across mid-evaluation user-agent/viewport changes

### DIFF
--- a/.changeset/playwright-driver-keep-document.md
+++ b/.changeset/playwright-driver-keep-document.md
@@ -1,0 +1,5 @@
+---
+"@qualweb/playwright-driver": patch
+---
+
+Keep the loaded document when the user agent or viewport flags change mid-evaluation. Previously the driver recreated its browser context on any such change; when `evaluate()` was called without a `viewport` option, `QualwebPage.setViewport` re-sends the default user agent during the ACT rules module's special-case viewport pass, and the recreation destroyed the loaded page and every injected bundle — the evaluation then failed (`window.act` undefined) and the URL produced no report. Context recreation now only happens while no document is loaded; afterwards, resizes apply to the live page and user-agent/flag changes are kept for a later context.

--- a/packages/playwright-driver/src/PlaywrightDriverPage.ts
+++ b/packages/playwright-driver/src/PlaywrightDriverPage.ts
@@ -23,11 +23,15 @@ const DEFAULT_VIEWPORT: Required<Omit<DriverViewport, 'deviceScaleFactor'>> & { 
  * Several per-page concepts in Puppeteer (CSP bypass, user agent, the
  * isMobile/hasTouch viewport flags) are context-creation options in
  * Playwright. This class owns a dedicated {@link BrowserContext} per page
- * and transparently recreates it when one of those settings changes.
- * Recreation discards any loaded document, so those settings must be
- * changed *before* navigation - which is the only order QualWeb itself
- * uses (setBypassCSP and setViewport/setUserAgent both happen before
- * goto/setContent in QualwebPage.getTestingData).
+ * and transparently recreates it when one of those settings changes -
+ * but only while no document is loaded. Recreation discards the loaded
+ * document and every injected script, so once goto()/setContent() has run,
+ * such changes keep the live page and only take effect on a later context.
+ * This matters in practice: when no viewport option is passed to
+ * evaluate(), QualwebPage.setViewport re-sends the default user agent
+ * during the ACT rules module's mid-evaluation special-case viewport pass,
+ * and recreating the context there would destroy the in-page evaluation
+ * state (window.act and the injected bundles).
  */
 export class PlaywrightDriverPage implements DriverPage {
   private context: BrowserContext;
@@ -36,6 +40,7 @@ export class PlaywrightDriverPage implements DriverPage {
   private userAgent?: string;
   private bypassCSP = true;
   private dismissingDialogs = false;
+  private hasDocument = false;
 
   private constructor(
     private readonly browser: Browser,
@@ -123,6 +128,7 @@ export class PlaywrightDriverPage implements DriverPage {
       timeout: options?.timeout,
       waitUntil: mapLoadEvent(options?.waitUntil)
     });
+    this.hasDocument = true;
   }
 
   public content(): Promise<string> {
@@ -139,10 +145,12 @@ export class PlaywrightDriverPage implements DriverPage {
   }
 
   public async goto(url: string, options?: NavigationOptions): Promise<DriverResponse | null> {
-    return this.page.goto(url, {
+    const response = await this.page.goto(url, {
       timeout: options?.timeout,
       waitUntil: mapLoadEvent(options?.waitUntil)
     });
+    this.hasDocument = true;
+    return response;
   }
 
   public viewport(): DriverViewport | null {
@@ -164,11 +172,14 @@ export class PlaywrightDriverPage implements DriverPage {
       hasTouch: !!viewport.hasTouch
     };
 
-    if (flagsChanged) {
+    if (flagsChanged && !this.hasDocument) {
       // isMobile/hasTouch/deviceScaleFactor are context-creation options in
       // Playwright and cannot be changed on a live page.
       await this.recreateContext();
     } else {
+      // With a document loaded, recreation would destroy the page and any
+      // injected scripts, so apply what a live page supports (the
+      // dimensions) and keep the flags for a later context.
       await this.page.setViewportSize({ width: viewport.width, height: viewport.height });
     }
   }
@@ -176,8 +187,12 @@ export class PlaywrightDriverPage implements DriverPage {
   public async setUserAgent(userAgent: string): Promise<void> {
     if (userAgent !== (this.userAgent ?? this.browserUserAgent)) {
       this.userAgent = userAgent;
-      // The user agent is a context-creation option in Playwright.
-      await this.recreateContext();
+      // The user agent is a context-creation option in Playwright. With a
+      // document loaded, keep the live page (see the class doc); the new
+      // user agent applies if the context is ever recreated.
+      if (!this.hasDocument) {
+        await this.recreateContext();
+      }
     }
   }
 
@@ -235,6 +250,7 @@ export class PlaywrightDriverPage implements DriverPage {
 
     this.context = await this.browser.newContext(options);
     this.page = await this.context.newPage();
+    this.hasDocument = false;
 
     if (this.dismissingDialogs) {
       this.registerDialogHandler();

--- a/packages/playwright-driver/test/driver.spec.ts
+++ b/packages/playwright-driver/test/driver.spec.ts
@@ -139,6 +139,44 @@ describe('PlaywrightDriver', function () {
     expect(widthAfter).to.equal(widthBefore);
   });
 
+  it('Should keep the loaded document across mid-evaluation viewport/user-agent changes', async function () {
+    // Regression test: when evaluate() is called WITHOUT a viewport option,
+    // QualwebPage.setViewport re-sends the default user agent during
+    // mid-evaluation resizes (the ACT rules special-case pass). Recreating
+    // the context there destroys the loaded document and every injected
+    // script - the resize must keep the live page.
+    let markerAfterResize: number | undefined;
+    let titleAfterResize = '';
+    let widthDuring = 0;
+
+    const dummyModule = new DummyModule(undefined, async (page: QualwebPage) => {
+      await page.evaluate(() => {
+        (window as unknown as { qualwebStateMarker: number }).qualwebStateMarker = 42;
+      });
+
+      // Mirrors ACTRulesModule.runModule's special-case pass, which goes
+      // through QualwebPage.setViewport and therefore also setUserAgent.
+      await page.setViewport({ resolution: { width: 640, height: 512 } });
+
+      widthDuring = await page.evaluate(() => window.innerWidth) as number;
+      markerAfterResize = await page.evaluate(
+        () => (window as unknown as { qualwebStateMarker?: number }).qualwebStateMarker
+      ) as number | undefined;
+      titleAfterResize = await page.evaluate(() => document.title) as string;
+
+      return DummyModule.emptyReport();
+    });
+
+    const qualweb = makeQualweb();
+    await qualweb.start();
+    await qualweb.evaluate({ url: host, modules: [dummyModule] });
+    await qualweb.stop();
+
+    expect(widthDuring).to.equal(640);
+    expect(markerAfterResize).to.equal(42);
+    expect(titleAfterResize).to.equal('Fixture root');
+  });
+
   it('Should map Puppeteer-style waitUntil values', async function () {
     const qualweb = makeQualweb();
     await qualweb.start();


### PR DESCRIPTION
Fixes #333.

Evaluations run through `@qualweb/playwright-driver` **without a `viewport` option** lost their page mid-evaluation: `QualwebPage.setViewport` re-sends the default user agent during the ACT rules module's special-case viewport pass, the driver treated the user-agent change as requiring context recreation, and recreation destroyed the loaded document, the injected bundles, and `window.act` — the evaluation failed and the URL produced no report. Full chain of events in #333.

## Fix

`PlaywrightDriverPage` now tracks whether a document has been loaded (`goto`/`setContent`, reset on recreation). While no document is loaded, behavior is unchanged: user-agent, CSP, and viewport-flag changes recreate the context as before. Once a document is loaded, the context is never recreated: resizes apply to the live page via `setViewportSize`, and user-agent/flag changes are recorded for a later context. This is what the mid-evaluation pass actually needs (the resize), and mirrors the practical Puppeteer semantics, where `setUserAgent` on a loaded page doesn't reload the document.

## Testing

- New regression test ("Should keep the loaded document across mid-evaluation viewport/user-agent changes") reproduces the default-options shape: a module sets an in-page marker, resizes via `QualwebPage.setViewport`, and asserts the marker and document survive. Fails on `main` with `expected undefined to equal 42`; passes with the fix.
- The pre-existing mid-evaluation resize test kept passing on `main` because it only measured `window.innerWidth`, which recreation happens to preserve — hence the dedicated state-survival assertions.
- Full package suite: 13 passing.
- Verified downstream in the consumer that hit this (testaro's qualWeb integration switched to this driver): evaluations without a viewport option now complete with results matching the Puppeteer driver.

Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)