### PR TITLE
fix(util, act-rules): allow caption as an owned element of table, grid and treegrid

### DIFF
--- a/.changeset/grid-caption-allowed-owned.md
+++ b/.changeset/grid-caption-allowed-owned.md
@@ -1,0 +1,6 @@
+---
+'@qualweb/util': patch
+'@qualweb/act-rules': patch
+---
+
+QW-ACT-R38 no longer fails `table`, `grid` and `treegrid` elements that own a `caption` (#254). The roles data gains an `allowedOwnedElements` field for owned roles that are allowed without being required, the duplicate `row` entry in `grid.requiredOwnedElements` was removed, the `tablegrid` typo in `caption.requiredContextRole` is now `treegrid` (also fixes QW-ACT-R33 for captions inside treegrids), and QW-ACT-R38 no longer mutates the shared roles data while checking group children.

--- a/packages/act-rules/src/rules/QW-ACT-R38.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R38.ts
@@ -20,11 +20,13 @@ class QW_ACT_R38 extends AtomicRule {
     // ancestor with aria-busy="true".
     const role = window.AccessibilityUtils.getElementRole(element);
     const requiredOwnedElements = role ? rolesJSON[role]?.['requiredOwnedElements'] : undefined;
+    const allowedOwnedElements = role ? rolesJSON[role]?.['allowedOwnedElements'] : undefined;
     const ariaBusy = this.isElementADescendantOfAriaBusy(element) || element.getElementAttribute('aria-busy');
 
     if (requiredOwnedElements && requiredOwnedElements.length > 0 && !ariaBusy) {
       const result = this.checkOwnedElementsRole(
         requiredOwnedElements,
+        allowedOwnedElements,
         window.AccessibilityUtils.getOwnedElements(element)
       );
 
@@ -41,7 +43,11 @@ class QW_ACT_R38 extends AtomicRule {
     }
   }
 
-  private checkOwnedElementsRole(ownedRoles: string[] | undefined, elements: QWElement[]): boolean {
+  private checkOwnedElementsRole(
+    ownedRoles: string[] | undefined,
+    allowedRoles: string[] | undefined,
+    elements: QWElement[]
+  ): boolean {
     if (ownedRoles?.length === 0) return true;
     const rolesJSON = window.AccessibilityUtils.roles;
     let onlyOwnedRoles = true;
@@ -55,20 +61,30 @@ class QW_ACT_R38 extends AtomicRule {
       if (!role || role === 'none') {
         break;
       }
-      //console.log({ ownedRoles, role });
+      if (allowedRoles?.includes(role)) {
+        // Allowed accessibility child roles (e.g. `caption` in `table`, `grid`
+        // or `treegrid`) may be owned but don't count towards the required
+        // owned elements.
+        i++;
+        continue;
+      }
       if (role.includes('group')) {
         const roles = rolesJSON[role]['requiredOwnedElements'];
         if (roles) {
-          roles.push(...(ownedRoles ?? []));
           hasOwnedRole =
             ownedRoles?.includes(role) &&
-            this.checkOwnedElementsRole(roles, window.AccessibilityUtils.getOwnedElements(currentElement));
+            this.checkOwnedElementsRole(
+              [...roles, ...(ownedRoles ?? [])],
+              rolesJSON[role]['allowedOwnedElements'],
+              window.AccessibilityUtils.getOwnedElements(currentElement)
+            );
         }
       } else {
         hasOwnedRole =
           ownedRoles?.includes(role) &&
           this.checkOwnedElementsRole(
             rolesJSON[role]['requiredOwnedElements'],
+            rolesJSON[role]['allowedOwnedElements'],
             window.AccessibilityUtils.getOwnedElements(currentElement)
           );
       }

--- a/packages/act-rules/test/qw-act-r38.spec.ts
+++ b/packages/act-rules/test/qw-act-r38.spec.ts
@@ -1,0 +1,142 @@
+import { expect } from 'chai';
+import { launchBrowser } from './util';
+import { LocaleFetcher } from '@qualweb/locale';
+import { Browser } from 'puppeteer';
+
+/**
+ * Regression tests for https://github.com/qualweb/qualweb/issues/254
+ *
+ * `caption` is an allowed (but not required) owned element of `table`, `grid`
+ * and `treegrid` (WAI-ARIA 1.2 caption definition; "allowed accessibility
+ * child roles" in the ARIA 1.3 draft). QW-ACT-R38 must not fail an element
+ * just because it owns a caption, and QW-ACT-R33 must accept `caption` inside
+ * `treegrid`.
+ */
+describe('QW-ACT-R38 allowed owned elements (issue #254)', function () {
+  let browser: Browser;
+
+  before(async () => {
+    browser = await launchBrowser();
+  });
+
+  after(async () => {
+    await browser.close();
+  });
+
+  async function evaluate(sourceCode: string): Promise<any> {
+    const incognito = await browser.createBrowserContext();
+    const page = await incognito.newPage();
+
+    try {
+      await page.setContent(sourceCode, { waitUntil: 'load' });
+
+      await page.addScriptTag({
+        path: require.resolve('@qualweb/qw-page')
+      });
+
+      await page.addScriptTag({
+        path: require.resolve('@qualweb/util')
+      });
+
+      await page.addScriptTag({
+        path: require.resolve('../dist/__webpack/act.bundle.js')
+      });
+
+      return await page.evaluate(
+        (locale, sourceCode) => {
+          // @ts-expect-error: ACTRulesRunner will be defined within the puppeteer execution context.
+          window.act = new ACTRulesRunner(
+            { include: ['QW-ACT-R33', 'QW-ACT-R38'] },
+            { translate: locale, fallback: locale }
+          );
+          // @ts-expect-error: window.act has been defined earlier.
+          window.act.configure({ include: ['QW-ACT-R33', 'QW-ACT-R38'] });
+          // @ts-expect-error: window.act has been defined earlier.
+          window.act.test({ sourceHtml: sourceCode });
+          // @ts-expect-error: window.act has been defined earlier.
+          return window.act.getReport();
+        },
+        LocaleFetcher.get('en'),
+        sourceCode
+      );
+    } finally {
+      await incognito.close();
+    }
+  }
+
+  it('QW-ACT-R38 passes a native table with a caption', async function () {
+    this.timeout(0);
+
+    const report = await evaluate(
+      `<!DOCTYPE html><html lang="en"><head><title>t</title></head><body>
+        <table>
+          <caption>Monthly savings</caption>
+          <tr><th>Month</th><th>Savings</th></tr>
+          <tr><td>January</td><td>$100</td></tr>
+        </table>
+      </body></html>`
+    );
+
+    expect(report.assertions['QW-ACT-R38'].metadata.outcome).to.equal('passed');
+  });
+
+  it('QW-ACT-R38 passes a grid with a caption and rows', async function () {
+    this.timeout(0);
+
+    const report = await evaluate(
+      `<!DOCTYPE html><html lang="en"><head><title>t</title></head><body>
+        <table role="grid">
+          <caption>A caption</caption>
+          <tr role="row"><td role="gridcell">cell 1</td><td role="gridcell">cell 2</td></tr>
+        </table>
+      </body></html>`
+    );
+
+    expect(report.assertions['QW-ACT-R38'].metadata.outcome).to.equal('passed');
+  });
+
+  it('QW-ACT-R38 and QW-ACT-R33 pass an explicit caption role inside a treegrid', async function () {
+    this.timeout(0);
+
+    const report = await evaluate(
+      `<!DOCTYPE html><html lang="en"><head><title>t</title></head><body>
+        <div role="treegrid">
+          <div role="caption">Treegrid caption</div>
+          <div role="row"><div role="gridcell">x</div></div>
+        </div>
+      </body></html>`
+    );
+
+    expect(report.assertions['QW-ACT-R38'].metadata.outcome).to.equal('passed');
+    expect(report.assertions['QW-ACT-R33'].metadata.outcome).to.equal('passed');
+  });
+
+  it('QW-ACT-R38 still fails a grid that owns a disallowed role', async function () {
+    this.timeout(0);
+
+    const report = await evaluate(
+      `<!DOCTYPE html><html lang="en"><head><title>t</title></head><body>
+        <div role="grid">
+          <div role="listitem">not allowed here</div>
+          <div role="row"><div role="gridcell">x</div></div>
+        </div>
+      </body></html>`
+    );
+
+    expect(report.assertions['QW-ACT-R38'].metadata.outcome).to.equal('failed');
+  });
+
+  it('QW-ACT-R38 still fails a grid whose only owned element is a caption', async function () {
+    this.timeout(0);
+
+    const report = await evaluate(
+      `<!DOCTYPE html><html lang="en"><head><title>t</title></head><body>
+        <table role="grid">
+          <caption>Caption only, no rows</caption>
+        </table>
+      </body></html>`
+    );
+
+    expect(report.assertions['QW-ACT-R38'].metadata.outcome).to.equal('failed');
+  });
+});

--- a/packages/act-rules/test/qw-act-r38.spec.ts
+++ b/packages/act-rules/test/qw-act-r38.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { launchBrowser } from './util';
-import { LocaleFetcher } from '@qualweb/locale';
 import { Browser } from 'puppeteer';
 
 /**
@@ -39,26 +38,23 @@ describe('QW-ACT-R38 allowed owned elements (issue #254)', function () {
       });
 
       await page.addScriptTag({
+        path: require.resolve('@qualweb/locale')
+      });
+
+      await page.addScriptTag({
         path: require.resolve('../dist/__webpack/act.bundle.js')
       });
 
-      return await page.evaluate(
-        (locale, sourceCode) => {
-          // @ts-expect-error: ACTRulesRunner will be defined within the puppeteer execution context.
-          window.act = new ACTRulesRunner(
-            { include: ['QW-ACT-R33', 'QW-ACT-R38'] },
-            { translate: locale, fallback: locale }
-          );
-          // @ts-expect-error: window.act has been defined earlier.
-          window.act.configure({ include: ['QW-ACT-R33', 'QW-ACT-R38'] });
-          // @ts-expect-error: window.act has been defined earlier.
-          window.act.test({ sourceHtml: sourceCode });
-          // @ts-expect-error: window.act has been defined earlier.
-          return window.act.getReport();
-        },
-        LocaleFetcher.get('en'),
-        sourceCode
-      );
+      return await page.evaluate((sourceCode) => {
+        // @ts-expect-error: ACTRulesRunner will be defined within the puppeteer execution context.
+        window.act = new ACTRulesRunner({ include: ['QW-ACT-R33', 'QW-ACT-R38'] }, 'en');
+        // @ts-expect-error: window.act has been defined earlier.
+        window.act.configure();
+        // @ts-expect-error: window.act has been defined earlier.
+        window.act.test({ sourceHtml: sourceCode });
+        // @ts-expect-error: window.act has been defined earlier.
+        return window.act.getReport();
+      }, sourceCode);
     } finally {
       await incognito.close();
     }

--- a/packages/util/src/accessibilityUtils/roles.ts
+++ b/packages/util/src/accessibilityUtils/roles.ts
@@ -6,6 +6,7 @@ export type RoleInfo = {
   supportedAria: string | string[];
   implicitValueRoles: string[][];
   requiredOwnedElements?: string[];
+  allowedOwnedElements?: string[];
   prohibitedAria?: string[];
 };
 
@@ -223,7 +224,7 @@ export const roles: Roles = {
   caption: {
     baseConcept: '',
     attribute: '',
-    requiredContextRole: ['figure', 'grid', 'table', 'tablegrid'],
+    requiredContextRole: ['figure', 'grid', 'table', 'treegrid'],
     requiredAria: '',
     supportedAria: [
       'aria-atomic',
@@ -818,7 +819,8 @@ export const roles: Roles = {
       'aria-rowcount'
     ],
     implicitValueRoles: [['', '']],
-    requiredOwnedElements: ['row', 'rowgroup', 'row']
+    requiredOwnedElements: ['row', 'rowgroup'],
+    allowedOwnedElements: ['caption']
   },
   gridcell: {
     baseConcept: ['td'],
@@ -2401,7 +2403,8 @@ export const roles: Roles = {
       'aria-roledescription'
     ],
     implicitValueRoles: [['', '']],
-    requiredOwnedElements: ['row', 'rowgroup']
+    requiredOwnedElements: ['row', 'rowgroup'],
+    allowedOwnedElements: ['caption']
   },
   tablist: {
     baseConcept: '',
@@ -2705,7 +2708,8 @@ export const roles: Roles = {
       'aria-rowcount'
     ],
     implicitValueRoles: [['', '']],
-    requiredOwnedElements: ['row', 'rowgroup']
+    requiredOwnedElements: ['row', 'rowgroup'],
+    allowedOwnedElements: ['caption']
   },
   treeitem: {
     baseConcept: '',


### PR DESCRIPTION
Fixes #254.

## Problem

`QW-ACT-R38` ("ARIA required owned elements", ACT rule [bc4a75](https://www.w3.org/WAI/standards-guidelines/act/rules/bc4a75/)) enforces its expectation as *"the target owns **only** elements from its required owned element list"*. Since `caption` is not in the required owned element list of `table`/`grid`/`treegrid`, any of those roles owning a caption failed the rule — including a completely plain native table with no ARIA at all:

```html
<table>
  <caption>Monthly savings</caption>
  <tr><th>Month</th><th>Savings</th></tr>
  <tr><td>January</td><td>$100</td></tr>
</table>
```

Per [WAI-ARIA 1.2's `caption` definition](https://www.w3.org/TR/wai-aria-1.2/#caption), a caption *names a figure, table, grid, or treegrid* and SHOULD be their first child; the ARIA 1.3 draft formalizes this as an "allowed accessibility child role" of all three roles. The roles data in this repo already encodes that knowledge on the caption side (`caption.requiredContextRole` includes `grid`/`table`), the rule just never consulted it. axe-core's equivalent `aria-required-children` check passes the same markup.

None of the 24 official ACT test cases for bc4a75 contains a caption, which is why the test suite never caught this (the ACT community is aware the rule's "only owns" expectation over-fails allowed-but-not-required children — see act-rules/act-rules.github.io#1985).

## Changes

- **`@qualweb/util` roles data**: new optional `allowedOwnedElements` field — roles that may be owned without counting towards the required owned elements. Populated with `caption` for `table`, `grid` and `treegrid`. Also removes the duplicate `'row'` in `grid.requiredOwnedElements`, and fixes the `'tablegrid'` typo in `caption.requiredContextRole` (→ `'treegrid'`), which made `QW-ACT-R33` fail explicit `role="caption"` elements inside treegrids.
- **`QW-ACT-R38`**: owned elements whose role is in the owner's `allowedOwnedElements` are skipped — they don't fail the "only owns" check and don't count towards "has at least one required owned element" (a grid whose *only* owned element is a caption still fails). Also stops mutating the shared roles data when merging a group child's required owned elements with its parent's (`roles.push(...)` on the global object polluted e.g. `rowgroup.requiredOwnedElements` for the rest of the page evaluation).
- **Tests**: new `test/qw-act-r38.spec.ts` regression suite (5 cases: native table + caption, grid + caption, explicit caption role in treegrid for both R38 and R33, grid owning a disallowed role still fails, caption-only grid still fails).
- Changeset included (patch for `@qualweb/util` and `@qualweb/act-rules`).

## Verification

- New regression suite: 5/5 passing.
- All 39 official ACT test cases for bc4a75 (QW-ACT-R38) and ff89c9 (QW-ACT-R33) still pass.
- Manually verified with `@qualweb/core`: the issue's grid+caption markup and the native-table markup above now pass; a grid owning `role="listitem"` and a caption-only grid still fail.

## Notes / out of scope

- `separator` inside `menu`/`menubar` and headings inside `radiogroup` (the other allowed-children cases from act-rules/act-rules.github.io#1985) would fit the same `allowedOwnedElements` mechanism, but I kept this PR to the caption case reported in #254. Happy to extend it here or in a follow-up if you prefer.
- `checkOwnedElementsRole`'s early `break` when a child has no role (which makes verdicts order-dependent) is pre-existing behavior and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)