### PR TITLE
fix(act-rules, util): treat fully transparent text as not visible (#262)

### DIFF
--- a/.changeset/transparent-text-inapplicable.md
+++ b/.changeset/transparent-text-inapplicable.md
@@ -1,0 +1,6 @@
+---
+'@qualweb/util': patch
+'@qualweb/act-rules': patch
+---
+
+QW-ACT-R37 no longer fails intentionally invisible text (#262). Text whose effective foreground alpha is 0 (`color: transparent`, `color: rgba(…, 0)`, or `opacity: 0` — the common screen-reader-only hiding technique) is not visible per the ACT definition of visibility, so the rule is now inapplicable to it; transparent text with a `text-shadow` that may still render it legible keeps producing the W1 "can't tell" warning. Also fixes a dead `opacity: 0` check in `DomUtils.isElementVisible` (`opacity && opacity === 0` could never be true, and `parseInt` truncated fractional opacities), so fully transparent elements are now correctly treated as not visible by every visibility-gated rule.

--- a/packages/act-rules/src/rules/QW-ACT-R37.ts
+++ b/packages/act-rules/src/rules/QW-ACT-R37.ts
@@ -78,6 +78,14 @@ class QW_ACT_R37 extends AtomicRule {
       return;
     }
 
+    // Fully transparent text (color alpha × opacity === 0) is not visible —
+    // per the ACT definition of visibility, making it fully transparent
+    // changes no rendered pixels — so the rule is inapplicable. This is the
+    // common screen-reader-only technique from issue #262. Checked after the
+    // text-shadow warning because a shadow can still render such text legible.
+    const parsedFG = this.parseRGBString(fgColor);
+    if (parsedFG && parsedFG.alpha * opacity === 0) return;
+
     // Image background → cannot be evaluated automatically.
     if (this.isImage(bgColor)) {
       this.emit(test, element, Verdict.WARNING, 'W2');
@@ -104,7 +112,6 @@ class QW_ACT_R37 extends AtomicRule {
     }
     const parsedBG = background.color;
 
-    const parsedFG = this.parseRGBString(fgColor);
     // NOTE: if the foreground colour can't be parsed, no result is emitted —
     // kept as-is to avoid inventing a result code without a matching i18n entry.
     if (!parsedFG) return;

--- a/packages/act-rules/test/qw-act-r37-transparent.spec.ts
+++ b/packages/act-rules/test/qw-act-r37-transparent.spec.ts
@@ -1,0 +1,125 @@
+import { expect } from 'chai';
+import { launchBrowser } from './util';
+import { LocaleFetcher } from '@qualweb/locale';
+import { Browser } from 'puppeteer';
+
+/**
+ * Regression tests for https://github.com/qualweb/qualweb/issues/262
+ *
+ * Text with a fully transparent foreground (color alpha × opacity === 0) is
+ * not visible per the ACT definition of visibility, so QW-ACT-R37 must not
+ * report a contrast failure for it. This covers the common screen-reader-only
+ * technique of hiding text with `color: transparent` (and `opacity: 0`, which
+ * additionally exercises the fixed opacity check in DomUtils.isElementVisible).
+ */
+describe('QW-ACT-R37 transparent text (issue #262)', function () {
+  let browser: Browser;
+
+  before(async () => {
+    browser = await launchBrowser();
+  });
+
+  after(async () => {
+    await browser.close();
+  });
+
+  async function evaluate(sourceCode: string): Promise<any> {
+    const incognito = await browser.createBrowserContext();
+    const page = await incognito.newPage();
+
+    try {
+      await page.setContent(sourceCode, { waitUntil: 'load' });
+
+      await page.addScriptTag({
+        path: require.resolve('@qualweb/qw-page')
+      });
+
+      await page.addScriptTag({
+        path: require.resolve('@qualweb/util')
+      });
+
+      await page.addScriptTag({
+        path: require.resolve('../dist/__webpack/act.bundle.js')
+      });
+
+      return await page.evaluate(
+        (locale, sourceCode) => {
+          // @ts-expect-error: ACTRulesRunner will be defined within the puppeteer execution context.
+          window.act = new ACTRulesRunner({ include: ['QW-ACT-R37'] }, { translate: locale, fallback: locale });
+          // @ts-expect-error: window.act has been defined earlier.
+          window.act.configure({ include: ['QW-ACT-R37'] });
+          // @ts-expect-error: window.act has been defined earlier.
+          window.act.test({ sourceHtml: sourceCode });
+          // @ts-expect-error: window.act has been defined earlier.
+          return window.act.getReport();
+        },
+        LocaleFetcher.get('en'),
+        sourceCode
+      );
+    } finally {
+      await incognito.close();
+    }
+  }
+
+  async function outcomeOf(snippet: string): Promise<{ outcome: string; warning: number }> {
+    const report = await evaluate(
+      `<!DOCTYPE html><html lang="en"><head><title>t</title></head><body>${snippet}</body></html>`
+    );
+    const rule = report.assertions['QW-ACT-R37'];
+    return { outcome: rule.metadata.outcome, warning: rule.metadata.warning };
+  }
+
+  it('is inapplicable for text with color: transparent', async function () {
+    this.timeout(0);
+    const { outcome } = await outcomeOf(
+      `<p style="color: transparent">Invisible but screen-reader accessible</p>`
+    );
+    expect(outcome).to.equal('inapplicable');
+  });
+
+  it('is inapplicable for text with color: rgba(0, 0, 0, 0)', async function () {
+    this.timeout(0);
+    const { outcome } = await outcomeOf(
+      `<p style="color: rgba(0,0,0,0)">Invisible but screen-reader accessible</p>`
+    );
+    expect(outcome).to.equal('inapplicable');
+  });
+
+  it('is inapplicable for text that inherits a transparent color', async function () {
+    this.timeout(0);
+    const { outcome } = await outcomeOf(
+      `<div style="color: transparent"><span>Inherited invisible text</span></div>`
+    );
+    expect(outcome).to.equal('inapplicable');
+  });
+
+  it('is inapplicable for text hidden with opacity: 0', async function () {
+    this.timeout(0);
+    const { outcome } = await outcomeOf(`<p style="opacity: 0">Invisible via opacity</p>`);
+    expect(outcome).to.equal('inapplicable');
+  });
+
+  it('still warns for transparent text with a text-shadow that may render it legible', async function () {
+    this.timeout(0);
+    const { warning } = await outcomeOf(
+      `<p style="color: transparent; text-shadow: 2px 2px 4px #000">Shadow-rendered text</p>`
+    );
+    expect(warning).to.equal(1);
+  });
+
+  it('still fails genuinely low-contrast text', async function () {
+    this.timeout(0);
+    const { outcome } = await outcomeOf(
+      `<p style="color: #999; background-color: #fff">Genuinely low contrast text</p>`
+    );
+    expect(outcome).to.equal('failed');
+  });
+
+  it('still passes high-contrast text', async function () {
+    this.timeout(0);
+    const { outcome } = await outcomeOf(
+      `<p style="color: #000; background-color: #fff">High contrast text</p>`
+    );
+    expect(outcome).to.equal('passed');
+  });
+});

--- a/packages/util/src/domUtils/isElementVisible.ts
+++ b/packages/util/src/domUtils/isElementVisible.ts
@@ -2,31 +2,29 @@ import type { QWElement } from '@qualweb/qw-element';
 import elementHasOnePixel from './elementHasOnePixel';
 import elementHasContent from './elementHasContent';
 
+// parseFloat, not parseInt: computed opacity values are fractions
+// (parseInt('0.5') === 0 would treat half-transparent elements as hidden).
+function isFullyTransparent(element: QWElement): boolean {
+  const opacityProperty = element.getElementStyleProperty('opacity', '');
+  return opacityProperty ? parseFloat(opacityProperty) === 0 : false;
+}
+
 function isElementVisible(element: QWElement): boolean {
   const offScreen = element.isOffScreen();
   const cssHidden = window.DomUtils.isElementHiddenByCSS(element);
   const hasContent = elementHasContent(element, true);
   const hasOnePixelHeight = elementHasOnePixel(element);
-  const opacityProperty = element.getElementStyleProperty('opacity', '');
-  let opacity: number | undefined;
-  if (opacityProperty) {
-    opacity = parseInt(opacityProperty);
-  }
+  const transparent = isFullyTransparent(element);
   let opaqueParent: boolean = false;
   if (element.getElementParent()) {
     opaqueParent = isParentOpaque(element.getElementParent()!);
   }
 
-  return !(offScreen || hasOnePixelHeight || cssHidden || !hasContent || (opacity && opacity === 0) || opaqueParent);
+  return !(offScreen || hasOnePixelHeight || cssHidden || !hasContent || transparent || opaqueParent);
 }
 
 function isParentOpaque(element: QWElement): boolean {
-  const opacityProperty = element.getElementStyleProperty('opacity', '');
-  let opacity: number | undefined;
-  if (opacityProperty) {
-    opacity = parseInt(opacityProperty);
-  }
-  if (opacity && opacity === 0) {
+  if (isFullyTransparent(element)) {
     return true;
   }
   if (element.getElementParent()) {


### PR DESCRIPTION
Fixes #262.

## Problem

QW-ACT-R37 emits a guaranteed `F1` failure for intentionally invisible text — e.g. the common screen-reader-only technique `color: transparent`. A fully transparent foreground flattens onto the background during contrast computation, yielding the background color itself and therefore a 1:1 ratio, so such text can never pass.

Per [ACT afw4f7](https://www.w3.org/WAI/standards-guidelines/act/rules/afw4f7/), *visible* means "making it fully transparent would result in a difference in the pixels rendered" — alpha-0 text is definitionally invisible, so the rule should be **inapplicable**. This is the same class of case as ACT Inapplicable Example 3 (foreground equals background), which the rule already handles via its equal-colors early return.

Full analysis with a repro matrix: https://github.com/qualweb/qualweb/issues/262#issuecomment-4976039178

## Changes

1. **`QW-ACT-R37`**: return no result when the effective foreground alpha (color alpha × opacity) is 0. The check sits *after* the text-shadow check, so transparent text with a `text-shadow` that may still render it legible keeps producing the W1 "can't tell" warning.
2. **`DomUtils.isElementVisible`**: the `opacity: 0` check was dead code — `opacity && opacity === 0` can never be true (`0` is falsy) — so fully transparent elements were treated as visible by every rule gated on `ElementIsVisible`, and `opacity: 0` text failed R37 the same way. The check now uses `parseFloat` (not `parseInt`, which truncates fractional opacities like `0.5` to `0`) with an explicit `=== 0` comparison, in both `isElementVisible` and `isParentOpaque`.

### Why not `isElementHidden` / `isElementHiddenByCSSAux` (as suggested in the issue)?

Those utilities feed accessibility-tree reasoning across many rules, and `color: transparent` text is deliberately **not** hidden from assistive technology — that's the point of the technique. Treating it as globally hidden would break rules that check screen-reader-exposed content. Scoping the alpha check to R37's applicability matches the ACT visibility definition without side effects. (`opacity: 0` is different: it genuinely hides the element visually, which is exactly what `isElementVisible` is for.)

### Known limitations

`-webkit-text-stroke` and `background-clip: text` can render alpha-0 text visible; these remain out of scope, as with other automated checkers.

## Testing

- New regression suite `packages/act-rules/test/qw-act-r37-transparent.spec.ts` (7 cases): `color: transparent`, `color: rgba(0,0,0,0)`, inherited transparent color, and `opacity: 0` are inapplicable; transparent text with a legibility-affecting `text-shadow` still warns (W1); genuinely low-contrast text still fails; high-contrast text still passes.
- All 34 official W3C afw4f7 test cases for QW-ACT-R37 pass (41 passing total with the new suite).
- `packages/util` test suite passes (12/12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
