### PR TITLE
test(cui-checks): align units no-unit assertions with tri-state intent

### DIFF
--- a/.changeset/fuzzy-bobcats-switch.md
+++ b/.changeset/fuzzy-bobcats-switch.md
@@ -1,0 +1,11 @@
+---
+"@qualweb/cui-checks": patch
+---
+
+Align `unitsLocale` helper tests with the current tri-state behavior of `recognizeUnitByLocale`.
+
+- Keep `true` for recognized units in the target locale.
+- Keep `false` for units recognized in a different locale.
+- Expect `null` when no unit is recognized in the input text.
+
+This matches the helper and check semantics introduced after the original tests were added, where no recognized unit maps to an inapplicable outcome instead of a failure.

--- a/packages/cui-checks/test/unitsLocale.spec.ts
+++ b/packages/cui-checks/test/unitsLocale.spec.ts
@@ -27,21 +27,21 @@ describe('Get currency info by locale', () => {
                 this.timeout(50000);
                 const input = "This house is beautiful";
                 const results = recognizeUnitByLocale("en-US", input);
-                expect(results).to.be.false;
+                expect(results).to.be.null;
             });
 
             it('Should not recognize unit if not present (pt-PT)', function () {
                 this.timeout(50000);
                 const input = "Esta casa é bonita";
                 const results = recognizeUnitByLocale("pt-PT", input);
-                expect(results).to.be.false;
+                expect(results).to.be.null;
             });
 
             it('Should not recognize unit if not present (de-DE)', function () {
                 this.timeout(50000);
                 const input = "Dieses Haus ist schön";
                 const results = recognizeUnitByLocale("de-DE", input);
-                expect(results).to.be.false;
+                expect(results).to.be.null;
             });
         });
 


### PR DESCRIPTION
## Summary

This PR updates three assertions in `packages/cui-checks/test/unitsLocale.spec.ts` to expect `null` (instead of `false`) when no unit is recognized in the input text.

It also includes a changeset:
- `.changeset/fuzzy-bobcats-switch.md`

## Why this change is correct

The failing CI assertions were introduced in commit `311134a5` when these helper tests were first added. At that time, helper behavior was effectively binary for this case.

Later, the unit recognition semantics evolved (commit `86b9ed75`) to a tri-state contract:
- `true`: unit recognized in the target locale
- `false`: unit recognized, but in a different locale
- `null`: no unit recognized

The same commit also updated `QW-CUI-C7` so `null` maps to an **inapplicable** outcome, and added fixtures for that behavior (for example, no-unit content as inapplicable).

So these three assertions were stale relative to current intent/implementation and caused:
- `AssertionError: expected null to be false`

## Scope

Only these files are included:
- `packages/cui-checks/test/unitsLocale.spec.ts`
- `.changeset/fuzzy-bobcats-switch.md`

No runtime logic was changed.
