### PR TITLE
test(counter): remove ESM bootstrap from CommonJS counter spec

### DIFF
--- a/.changeset/small-zebras-wave.md
+++ b/.changeset/small-zebras-wave.md
@@ -1,0 +1,7 @@
+---
+"@qualweb/counter": patch
+---
+
+Fix CommonJS test bootstrap in `counter.spec.ts` by removing `import.meta`/`createRequire` setup.
+
+The counter test suite runs with `ts-node/register` in a CommonJS context, where `require` and `__dirname` are already available. This avoids TypeScript/CommonJS errors in CI and local test runs.

--- a/packages/counter/test/counter.spec.ts
+++ b/packages/counter/test/counter.spec.ts
@@ -1,11 +1,6 @@
 import { expect } from 'chai';
-import { createRequire } from 'module';
-import { dirname, resolve } from 'path';
+import { resolve } from 'path';
 import puppeteer, { Browser, Page } from 'puppeteer';
-import { fileURLToPath } from 'url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const require = createRequire(import.meta.url);
 
 describe('QualWeb counter', async () => {
   let browser: Browser;


### PR DESCRIPTION
## Summary

This PR makes a minimal test-only fix in `@qualweb/counter`:

- Removes `import.meta` / `createRequire` / `fileURLToPath` setup from `packages/counter/test/counter.spec.ts`
- Keeps path resolution with existing CommonJS globals (`require`, `__dirname`) available under `ts-node/register`
- Adds a changeset:
  - `.changeset/small-zebras-wave.md`

## Why

The counter tests run in a CommonJS context (`mocha -r ts-node/register`). In that context, using `import.meta` causes TypeScript/CommonJS errors (`TS1470`) and creating a local `require` collides with CommonJS typing.

This change aligns the test bootstrap with the runtime mode while preserving test behavior.

## Validation

Executed under Node 20:

- `npm test -w @qualweb/counter -- test/counter.spec.ts`
- Result: `1 passing`

## Scope

Only these files changed:

- `packages/counter/test/counter.spec.ts`
- `.changeset/small-zebras-wave.md`
