### PR TITLE
test(qw-page): fix CommonJS bootstrap in page.spec.ts (workflow TS1470/TS2441)

### DIFF
--- a/.changeset/green-goats-exist.md
+++ b/.changeset/green-goats-exist.md
@@ -1,0 +1,7 @@
+---
+"@qualweb/qw-page": patch
+---
+
+Fix CommonJS test bootstrap in `packages/qw-page/test/page.spec.ts` by removing `import.meta` and `createRequire` usage.
+
+The test runs via `ts-node/register` in CommonJS mode, where `require` and `__dirname` are already available. This avoids `TS1470` and `TS2441` workflow failures.

--- a/packages/qw-page/test/page.spec.ts
+++ b/packages/qw-page/test/page.spec.ts
@@ -1,13 +1,6 @@
 import puppeteer from 'puppeteer';
 import { expect } from 'chai';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-import { createRequire } from 'module';
 import type { QWPage } from '../src/index.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-const require = createRequire(import.meta.url);
 
 declare global {
   interface Window {


### PR DESCRIPTION
## Summary

This PR fixes the `@qualweb/qw-page` test bootstrap in CommonJS mode.

### Changes

- Updated `packages/qw-page/test/page.spec.ts`
  - removed `import.meta` / `fileURLToPath` / `dirname` bootstrap
  - removed `createRequire` and local `require` redeclaration
  - kept existing test behavior and assertions unchanged
- Added changeset:
  - `.changeset/green-goats-exist.md`

## Why this fixes the failing workflow

The failing workflow log (`workflow_fail.txt`) shows **compile-time TypeScript errors** in `test/page.spec.ts`:

- `TS1470`: `import.meta` is not allowed when the test compiles to CommonJS output
- `TS2441`: duplicate identifier `require`

Relevant log lines:

- `workflow_fail.txt` line 764: `test/page.spec.ts(8,34): error TS1470`
- `workflow_fail.txt` line 765: `test/page.spec.ts(10,7): error TS2441`
- `workflow_fail.txt` line 766: `test/page.spec.ts(10,31): error TS1470`

This patch removes those CommonJS-incompatible constructs from the test file, so the test can compile and run correctly in the workflow's current test runtime setup.

## Local verification

Ran locally under Node 20:

- `npm test -w @qualweb/qw-page`
- Result: `1 passing`

## Scope

Only these files are included:

- `packages/qw-page/test/page.spec.ts`
- `.changeset/green-goats-exist.md`
