### PR TITLE
chore: add root CI parity scripts and testing docs

### DIFF
--- a/.changeset/tidy-hounds-care.md
+++ b/.changeset/tidy-hounds-care.md
@@ -1,0 +1,6 @@
+---
+---
+
+Add root CI parity scripts and testing documentation updates only.
+
+No package release is required for this change.

--- a/TESTING.md
+++ b/TESTING.md
@@ -6,6 +6,15 @@ verification testing being done in the repo.
 We use [Mocha](https://mochajs.org) (together with [Chai](https://www.chaijs.com))
 for our testing.
 
+## Root CI parity scripts
+
+The root package provides convenience scripts to run workspace checks in the same way as CI from the monorepo root:
+
+- `npm run lint:all`
+- `npm run build:all`
+- `npm run test:all`
+- `npm run ci:check` (runs lint, build, then tests)
+
 Each package has its own .mocharc.js configuration file. While all
 configurations derive from a base file .mocharc.base.json in the root of this
 repository, some may override base settings or add their own, depending on the

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "type": "git",
     "url": "git+https://github.com/qualweb/qualweb.git"
   },
-  "scripts": {},
+  "scripts": {
+    "lint:all": "npm run lint --workspaces --if-present",
+    "build:all": "npm run build --workspaces --if-present",
+    "test:all": "npm test --workspaces --if-present",
+    "ci:check": "npm run lint:all && npm run build:all && npm run test:all"
+  },
   "keywords": [
     "qualweb",
     "accessibility",


### PR DESCRIPTION
## Summary

This PR implements root-level CI parity scripts and documenting them.

### Changes

- `package.json`
  - adds:
    - `lint:all`: `npm run lint --workspaces --if-present`
    - `build:all`: `npm run build --workspaces --if-present`
    - `test:all`: `npm test --workspaces --if-present`
    - `ci:check`: `npm run lint:all && npm run build:all && npm run test:all`
- `TESTING.md`
  - adds a `Root CI parity scripts` section with usage notes.

## Scope

This PR intentionally includes only:

- `package.json`
- `TESTING.md`

## Local verification

Executed on Node 20:

- `npm run build:all` runs successfully (with existing webpack performance warnings)
- `npm run lint:all` executes and reports existing baseline lint/config issues
- `npm run test:all` executes and surfaces existing baseline `act-rules` hook failures

No runtime code changes are included.
