### PR TITLE
chore(lint): ignore generated dist and prebuild artifacts

### DIFF
--- a/.changeset/fresh-melons-joke.md
+++ b/.changeset/fresh-melons-joke.md
@@ -1,0 +1,6 @@
+---
+---
+
+Ignore generated dist and prebuild directories in shared ESLint configuration to reduce build-artifact lint noise.
+
+No package release is required for this maintenance change.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,13 +9,16 @@ import sonarjsPlugin from 'eslint-plugin-sonarjs';
 
 export const defaultConfig = [
   {
+    ignores: [
+      '**/dist/**',
+      '**/prebuild/**',
+    ],
+  },
+  {
     extends: [
       eslint.configs.recommended,
       ...tseslint.configs.recommended,
     ],
-    // ignores: [
-    //   './test/fixtures/**/*',
-    // ],
     files: [
       'src/**/*.ts',
       'test/**/*.ts',


### PR DESCRIPTION
## Summary

This PR excludes generated build artifacts from shared ESLint checks.

### Changes

- `eslint.config.mjs`
  - adds top-level ignores:
    - `**/dist/**`
    - `**/prebuild/**`
- `.changeset/fresh-melons-joke.md`
  - empty changeset note for this maintenance-only repository change.

## Why

Workspace lint output included many SonarJS findings from generated build outputs, which are not source-of-truth files and add noise to source-quality linting.

## Local validation

- Ran: `npm run lint --workspaces --if-present`
- Result:
  - dist/prebuild paths no longer appear in lint failures
  - lint still fails due to existing TS project resolution errors (`TS5012`), which are out of scope for this PR and tracked separately (PR #345).

## Scope

This PR is intentionally minimal and limited to lint target selection only.
