### PR TITLE
fix(eslint): use project service for workspace lint

### DIFF
--- a/.changeset/quiet-bikes-press.md
+++ b/.changeset/quiet-bikes-press.md
@@ -1,0 +1,6 @@
+---
+---
+
+Switch the shared ESLint config to project service so workspace lint can resolve package tsconfig files without TS5012 parsing errors.
+
+No package release is required for this maintenance change.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,9 @@ export const defaultConfig = [
     ],
     languageOptions: {
       parserOptions: {
-        project: 'tsconfig.json',
+        projectService: {
+          allowDefaultProject: ['packages/counter/test/counter.spec.ts'],
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

This PR switches the shared ESLint config to TypeScript project service, which avoids brittle root `tsconfig.json` resolution during workspace linting.

### Changes

- `eslint.config.mjs`
  - replaces `parserOptions.project: 'tsconfig.json'` with `parserOptions.projectService`
  - narrows fallback usage to the one counter test file that is not covered by a package project
- `.changeset/quiet-bikes-press.md`
  - empty changeset note for this maintenance-only config change.

## Validation

Locally verified with:

- `npm run lint --workspaces --if-present`

Result:

- `TS5012` parsing errors are gone
- remaining lint failures are unrelated source/build-artifact issues handled by other PRs

## Scope

This PR is intentionally limited to ESLint project resolution.
